### PR TITLE
Payment flow config

### DIFF
--- a/lib/adyen/configuration.rb
+++ b/lib/adyen/configuration.rb
@@ -4,6 +4,7 @@ class Adyen::Configuration
     @default_api_params  = {}
     @default_form_params = {}
     @form_skins          = {}
+    @payment_flow        = :select
   end
 
   # The Rails environment for which to use to Adyen "live" environment.
@@ -42,9 +43,9 @@ class Adyen::Configuration
   # The payment flow URL that’s used to choose the payement process
   #
   # @example
-  #   Adyen.configuration.payment_flow = 'select.shtml'
-  #   Adyen.configuration.payment_flow = 'pay.shtml'
-  #   Adyen.configuration.payment_flow = 'details.shtml'
+  #   Adyen.configuration.payment_flow = :select
+  #   Adyen.configuration.payment_flow = :pay
+  #   Adyen.configuration.payment_flow = :details
   #
   # @return [String]
   attr_accessor :payment_flow

--- a/lib/adyen/form.rb
+++ b/lib/adyen/form.rb
@@ -29,7 +29,7 @@ module Adyen
 
     # The URL of the Adyen payment system that still requires the current
     # Adyen enviroment and payment flow to be filled.
-    ACTION_URL = "https://%s.adyen.com/hpp/%s"
+    ACTION_URL = "https://%s.adyen.com/hpp/%s.shtml"
 
     # Returns the URL of the Adyen payment system, adjusted for an Adyen environment.
     #
@@ -39,10 +39,10 @@ module Adyen
     #    for payment forms or redirects.
     # @see Adyen::Form.environment
     # @see Adyen::Form.redirect_url
-    def url(environment = nil)
-      environment ||= Adyen.configuration.environment
-      payment_flow  = Adyen.configuration.payment_flow
-      Adyen::Form::ACTION_URL % [environment.to_s, payment_flow]
+    def url(environment = nil, payment_flow = nil)
+      environment  ||= Adyen.configuration.environment
+      payment_flow ||= Adyen.configuration.payment_flow
+      Adyen::Form::ACTION_URL % [environment.to_s, payment_flow.to_s]
     end
 
     ######################################################

--- a/spec/form_spec.rb
+++ b/spec/form_spec.rb
@@ -17,50 +17,37 @@ describe Adyen::Form do
       Adyen.configuration.environment = nil
     end
 
-    it "should generate correct the testing url" do
-      case Adyen.configuration.payment_flow
-        when 'select.shtml'
-          Adyen::Form.url.should == 'https://test.adyen.com/hpp/select.shtml'
-        when 'pay.shtml'
-          Adyen::Form.url.should == 'https://test.adyen.com/hpp/pay.shtml'
-        when 'details.shtml'
-          Adyen::Form.url.should == 'https://test.adyen.com/hpp/details.shtml'
-      end
+    it "should generate correct testing url" do
+      Adyen::Form.url.should == 'https://test.adyen.com/hpp/select.shtml'
     end
 
-    it "should generate a live url if the environemtn is set top live" do
+    it "should generate a live url if the environment is set to live" do
       Adyen.configuration.environment = :live
-      case Adyen.configuration.payment_flow
-        when 'select.shtml'
-          Adyen::Form.url.should == 'https://live.adyen.com/hpp/select.shtml'
-        when 'pay.shtml'
-          Adyen::Form.url.should == 'https://live.adyen.com/hpp/pay.shtml'
-        when 'details.shtml'
-          Adyen::Form.url.should == 'https://live.adyen.com/hpp/details.shtml'
-      end
+      Adyen::Form.url.should == 'https://live.adyen.com/hpp/select.shtml'
     end
 
     it "should generate correct live url in a production environment" do
       Adyen.configuration.stub!(:autodetect_environment).and_return('live')
-      case Adyen.configuration.payment_flow
-        when 'select.shtml'
-          Adyen::Form.url.should == 'https://live.adyen.com/hpp/select.shtml'
-        when 'pay.shtml'
-          Adyen::Form.url.should == 'https://live.adyen.com/hpp/pay.shtml'
-        when 'details.shtml'
-          Adyen::Form.url.should == 'https://live.adyen.com/hpp/details.shtml'
-      end
+      Adyen::Form.url.should. == 'https://live.adyen.com/hpp/select.shtml'
     end
 
     it "should generate correct live url if explicitely asked for" do
-      case Adyen.configuration.payment_flow
-        when 'select.shtml'
-          Adyen::Form.url(:live).should == 'https://live.adyen.com/hpp/select.shtml'
-        when 'pay.shtml'
-          Adyen::Form.url(:live).should == 'https://live.adyen.com/hpp/pay.shtml'
-        when 'details.shtml'
-          Adyen::Form.url(:live).should == 'https://live.adyen.com/hpp/details.shtml'
-      end
+      Adyen::Form.url(:live).should == 'https://live.adyen.com/hpp/select.shtml'
+    end
+    
+    it "should generate correct testing url if the payment flow selection is set to select" do
+      Adyen.configuration.payment_flow = :select
+      Adyen::Form.url.should == 'https://test.adyen.com/hpp/select.shtml'
+    end
+    
+    it "should generate correct testing url if the payment flow selection is set to pay" do
+      Adyen.configuration.payment_flow = :pay
+      Adyen::Form.url.should == 'https://test.adyen.com/hpp/pay.shtml'
+    end
+    
+    it "should generate correct testing url if the payment flow selection is set to details" do
+      Adyen.configuration.payment_flow = :details
+      Adyen::Form.url.should == 'https://test.adyen.com/hpp/details.shtml'
     end
   end
 


### PR DESCRIPTION
Hi,

This change makes possible to configure the payment flow selection ('select.shmtl', 'pay.shtml', details.shtml'). See Adyen Merchant Integration Manual, section "Payment Flow Selection"

Usage:

Adyen.configuration.payment_flow = 'pay.shtml'

Thanks,
Steve
