### PR TITLE
Implement non-recurring ELV payment.

### DIFF
--- a/lib/adyen/api.rb
+++ b/lib/adyen/api.rb
@@ -2,6 +2,8 @@ require 'adyen'
 require 'adyen/api/simple_soap_client'
 require 'adyen/api/payment_service'
 require 'adyen/api/recurring_service'
+require 'adyen/api/elv_payment_service'
+require 'adyen/api/elv'
 
 module Adyen
   # The API module contains classes that interact with the Adyen SOAP API.
@@ -339,6 +341,47 @@ module Adyen
           :shopper => shopper,
           payment_method => params
         }).store_token
+    end
+
+    # Authorise a one time payment via ELV.
+    #
+    # @example
+    #   response = Adyen::API.authorise_elv_payment(
+    #     invoice.id,
+    #     { :currency => 'EUR', :value => invoice.amount },
+    #     { :reference => user.id, :email => user.email, :ip => '8.8.8.8' },
+    #     { :holder_name => "Simon Hopper", :account_number => '1234567890', :bank_location_id => '12345678' }
+    #   )
+    #   response.authorized? # => true
+    #
+    # @param          [Numeric,String] reference      Your reference (ID) for this payment.
+    # @param          [Hash]           amount         A hash describing the money to charge.
+    # @param          [Hash]           shopper        A hash describing the shopper.
+    # @param          [Hash]           elv            A hash describing the ELV details.
+    #
+    # @option amount  [String]         :currency      The ISO currency code (EUR, GBP, USD, etc).
+    # @option amount  [Integer]        :value         The value of the payment in discrete cents,
+    #                                                 unless the currency does not have cents.
+    #
+    # @option shopper [Numeric,String] :reference     The shopper’s reference (ID).
+    # @option shopper [String]         :email         The shopper’s email address.
+    # @option shopper [String]         :ip            The shopper’s IP address.
+    #
+    # @option elv     [String]         :holder_name      The full name on the card.
+    # @option elv     [String]         :number           The account number.
+    # @option elv     [String]         :bank_location_id The card’s verification code.
+    # @option elv     [String]         :bank_location    The Bank Location (optional).
+    # @option elv     [String]         :bank_name        The Bank Name (optional).
+    #
+    # @return [PaymentService::AuthorisationResponse] The response object which holds the
+    #                                                 authorisation status.
+    def authorise_elv_payment(reference, amount, shopper, elv)
+      ElvPaymentService.new(
+        :reference => reference,
+        :amount    => amount,
+        :shopper   => shopper,
+        :elv       => elv
+      ).authorise_payment
     end
   end
 end

--- a/lib/adyen/api/elv.rb
+++ b/lib/adyen/api/elv.rb
@@ -1,0 +1,24 @@
+module Adyen
+  module API
+    module Elv
+      ELV_ATTRS           = [:bank_location, :bank_name, :bank_location_id, :holder_name, :number]
+      MANDATORY_ELV_ATTRS = [:bank_location_id, :holder_name, :number]
+
+      def elv_partial(options = {:recurring => true})
+        validate_parameters!(:elv => MANDATORY_ELV_ATTRS)
+        elv  = @params[:elv].values_at(*ELV_ATTRS)
+        (options[:recurring] ? ELV_PARTIAL_RECURRING : ELV_PARTIAL) % elv
+      end
+
+      def parse_elv_details
+        {
+          :holder_name      => bank.text('./payment:accountHolderName'),
+          :number           => bank.text('./payment:bankAccountNumber'),
+          :bank_location    => bank.text('./payment:bankLocation'),
+          :bank_location_id => bank.text('./payment:bankLocationId'),
+          :bank_name        => bank.text('./payment:bankName')
+        }
+      end
+    end
+  end
+end

--- a/lib/adyen/api/elv_payment_service.rb
+++ b/lib/adyen/api/elv_payment_service.rb
@@ -1,0 +1,20 @@
+require 'adyen/api/templates/elv_service'
+
+module Adyen
+  module API
+    class ElvPaymentService < PaymentService
+      include Elv
+
+      def authorise_payment
+        make_payment_request(authorise_payment_request_body, AuthorisationResponse)
+      end
+
+      private
+
+      def authorise_payment_request_body
+        payment_request_body elv_partial(:recurring => false)
+      end
+    end
+  end
+end
+

--- a/lib/adyen/api/templates/elv_service.rb
+++ b/lib/adyen/api/templates/elv_service.rb
@@ -1,0 +1,26 @@
+module Adyen
+  module API
+    module Elv
+      # Electronic bank debit in Germany. Semi real-time payment method.
+      ELV_PARTIAL = <<-EOS
+        <payment:elv>
+          <payment:bankLocation>%s</payment:bankLocation>
+          <payment:bankName>%s</payment:bankName>
+          <payment:bankLocationId>%s</payment:bankLocationId>
+          <payment:accountHolderName>%s</payment:accountHolderName>
+          <payment:bankAccountNumber>%02d</payment:bankAccountNumber>
+        </payment:elv>
+      EOS
+
+      ELV_PARTIAL_RECURRING = <<-EOS
+        <recurring:elv>
+          <payment:bankLocation>%s</payment:bankLocation>
+          <payment:bankName>%s</payment:bankName>
+          <payment:bankLocationId>%s</payment:bankLocationId>
+          <payment:accountHolderName>%s</payment:accountHolderName>
+          <payment:bankAccountNumber>%02d</payment:bankAccountNumber>
+        </recurring:elv>
+      EOS
+    end
+  end
+end

--- a/lib/adyen/api/templates/recurring_service.rb
+++ b/lib/adyen/api/templates/recurring_service.rb
@@ -54,17 +54,6 @@ EOS
           <payment:expiryMonth>%02d</payment:expiryMonth>
         </recurring:card>
 EOS
-      # Electronic bank debit in Germany. Semi real-time payment method.
-      # @private
-      ELV_PARTIAL = <<EOS
-        <recurring:elv>
-          <payment:bankLocation>%s</payment:bankLocation>
-          <payment:bankName>%s</payment:bankName>
-          <payment:bankLocationId>%s</payment:bankLocationId>
-          <payment:accountHolderName>%s</payment:accountHolderName>
-          <payment:bankAccountNumber>%02d</payment:bankAccountNumber>
-        </recurring:elv>
-EOS
 
     end
   end

--- a/spec/api/api_spec.rb
+++ b/spec/api/api_spec.rb
@@ -157,5 +157,32 @@ describe Adyen::API do
         Adyen::API.disable_recurring_contract('user-id', 'detail-id')
       end
     end
+
+    describe "shortcut methods" do
+      describe "for the ElvPaymentService" do
+        before do
+          @elv_payment = mock('ElvPaymentService')
+        end
+
+        def should_map_shortcut_to(method, params)
+          Adyen::API::ElvPaymentService.should_receive(:new).with(params).and_return(@elv_payment)
+          @elv_payment.should_receive(method)
+        end
+
+        it "performs a `authorise elv payment' request" do
+          should_map_shortcut_to(:authorise_payment,
+            :reference  => 'order-id',
+            :amount     => { :currency => 'EUR', :value => 1234 },
+            :shopper    => { :reference => 'user-id', :email => 's.hopper@example.com' },
+            :elv        => { :holder_name => "Simon Hopper", :number => '1234567890', :bank_location_id => '12345678' }
+          )
+          Adyen::API.authorise_elv_payment('order-id',
+            { :currency     => 'EUR', :value => 1234 },
+            { :reference    => 'user-id', :email => 's.hopper@example.com' },
+            { :holder_name  => "Simon Hopper", :number => '1234567890', :bank_location_id => '12345678' }
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/api/elv_payment_service_spec.rb
+++ b/spec/api/elv_payment_service_spec.rb
@@ -1,0 +1,45 @@
+# encoding: UTF-8
+require 'api/spec_helper'
+
+describe Adyen::API::ElvPaymentService do
+  include APISpecHelper
+
+  before do
+    @params = {
+      :reference => 'order-id',
+      :amount => {
+        :currency => 'EUR',
+        :value => '1234',
+      },
+      :shopper => {
+        :email => 's.hopper@example.com',
+        :reference => 'user-id',
+        :ip => '61.294.12.12',
+      },
+      :elv => {
+        :holder_name => 'Simon Hopper',
+        :number => '1234567890',
+        :bank_location_id => '12345678'
+      }
+    }
+    @payment = @object = Adyen::API::ElvPaymentService.new(@params)
+  end
+
+  describe_request_body_of :authorise_payment do
+    it_should_validate_request_parameters :elv => [:holder_name, :number, :bank_location_id]
+
+    it "includes the elv details" do
+      xpath('./payment:elv') do |elv|
+        elv.text('./payment:accountHolderName').should == 'Simon Hopper'
+        elv.text('./payment:bankAccountNumber').should == '1234567890'
+        elv.text('./payment:bankLocationId').should == '12345678'
+      end
+    end
+  end
+
+  private
+
+  def node_for_current_method
+    node_for_current_object_and_method.xpath('//payment:authorise/payment:paymentRequest')
+  end
+end


### PR DESCRIPTION
I know there has already been a commit implementing ELV for Adyen, however there is one _big_ problem with it: 
It's only usable for recurring payments, not for one time payments like with credit cards.
Adjusting existing logic was out of the question since this would have led to spaghetti code.

The attached pull request hopefully fixes this with minimal changing of existing logic.

What I did:

a) Add a new API method
b) Add a new, minimal payment service
c) Add an ELV module which encapsulates elv logic
d) Add a new template
e) Move elv logic out of the recurring payment service in one place
f) Add specs

Also, the existing validations for ELV were too strict, checking for bank_location and bank_name as well - all you need is holder name, bank_location_id and number.

I tested this pull request against the Adyen API and it worked as expected.

Please let me know what you think about this.
