### PR TITLE
No mass asignment within Notification Model Template

### DIFF
--- a/lib/adyen/templates/notification_model.rb
+++ b/lib/adyen/templates/notification_model.rb
@@ -16,20 +16,20 @@
 #      @invoice.set_paid!
 #    end
 class AdyenNotification < ActiveRecord::Base
-  
+
   # A notification should always include an event_code
   validates_presence_of :event_code
-  
+
   # A notification should always include a psp_reference
   validates_presence_of :psp_reference
-  
+
   # A notification should be unique using the composed key of
   # [:psp_reference, :event_code, :success]
   validates_uniqueness_of :success, :scope => [:psp_reference, :event_code]
-  
+
   # Make sure we don't end up with an original_reference with an empty string
   before_validation { |notification| notification.original_reference = nil if notification.original_reference.blank? }
-  
+
   # Logs an incoming notification into the database.
   #
   # @param [Hash] params The notification parameters that should be stored in the database.
@@ -38,15 +38,16 @@ class AdyenNotification < ActiveRecord::Base
   # @see Adyen::Notification::HttpPost.log
   def self.log(params)
     converted_params = {}
-    
-    # Convert each attribute from CamelCase notation to under_score notation
+
+    # Assign explicit each attribute from CamelCase notation to notification
     # For example, merchantReference will be converted to merchant_reference
-    params.each do |key, value|
-      column_name = key.to_s.underscore
-      converted_params[column_name] = value if self.column_names.include?(column_name)
+    self.new.tap do |notification|
+      params.each do |key, value|
+        column_name = key.to_s.underscore
+        notification.send("#{column_name}=", value) if self.column_names.include?(column_name)
+      end
+      notification.save!
     end
-    
-    self.create!(converted_params)
   end
 
   # Returns true if this notification is an AUTHORISATION notification
@@ -57,14 +58,14 @@ class AdyenNotification < ActiveRecord::Base
   end
 
   alias_method :authorization?, :authorisation?
-  
+
   # Returns true if this notification is an AUTHORISATION notification and
   # the success status indicates that the authorization was successfull.
   # @return [true, false] true iff  the notification is an authorization
   #   and the authorization was successful according to the success field.
   def successful_authorisation?
-    event_code == 'AUTHORISATION' && success?
+    authorisation? && success?
   end
-  
+
   alias_method :successful_authorization?, :successful_authorisation?
 end


### PR DESCRIPTION
Some small updates to Notification Model Template:
- Be Rails >= 3.2.3 friendly: don't use mass assignment, assign attributes explicit right away.
- Reuse already existing code. 
- No leading WS

No updated test, as there are none :-(
