### PR TITLE
Form#redirect_signature: don't fail on empty input

### DIFF
--- a/lib/adyen/form.rb
+++ b/lib/adyen/form.rb
@@ -194,8 +194,10 @@ module Adyen
     #    It should correspond with the skin_code parameter. This parameter can be
     #    left out if the shared_secret is included as key in the parameters.
     # @return [String] The signature of the payment request
+    # @raise [ArgumentError] Thrown if shared_secret is empty
     def calculate_signature(parameters, shared_secret = nil)
       shared_secret ||= parameters.delete(:shared_secret)
+      raise ArgumentError, "Cannot calculate payment request signature with empty shared_secret" if shared_secret.to_s.empty?
       Adyen::Encoding.hmac_base64(shared_secret, calculate_signature_string(parameters))
     end
 
@@ -219,9 +221,11 @@ module Adyen
     #     the original payment form. You can leave this out of the skin is registered
     #     using the {Adyen::Form.register_skin} method.
     # @return [String] The redirect signature
+    # @raise [ArgumentError] Thrown if shared_secret is empty
     def redirect_signature(params, shared_secret = nil)
       shared_secret ||= Adyen.configuration.form_skin_shared_secret_by_code(params[:skinCode])
-      Adyen::Encoding.hmac_base64(shared_secret.to_s, redirect_signature_string(params))
+      raise ArgumentError, "Cannot compute redirect signature with empty shared_secret" if shared_secret.to_s.empty?
+      Adyen::Encoding.hmac_base64(shared_secret, redirect_signature_string(params))
     end
 
     # Checks the redirect signature for this request by calcultating the signature from

--- a/spec/form_spec.rb
+++ b/spec/form_spec.rb
@@ -80,8 +80,17 @@ describe Adyen::Form do
       Adyen::Form.redirect_signature_check(@params).should be_true
     end
 
-    it "should return false on empty input" do
-      Adyen::Form.redirect_signature_check({}).should be_false
+    it "should raise ArgumentError on missing skinCode" do
+      expect do
+        @params.delete(:skinCode)
+        Adyen::Form.redirect_signature_check(@params).should be_false
+      end.to raise_error ArgumentError
+    end
+
+    it "should raise ArgumentError on empty input" do
+      expect do
+        Adyen::Form.redirect_signature_check({}).should be_false
+      end.to raise_error ArgumentError
     end
 
     it "should detect a tampered field" do
@@ -160,6 +169,13 @@ describe Adyen::Form do
     it "should calculate the signature correctly" do
       signature = Adyen::Form.calculate_signature(@parameters)
       signature.should == 'x58ZcRVL1H6y+XSeBGrySJ9ACVo='
+    end
+
+    it "should raise ArgumentError on empty shared_secret" do
+      expect do
+        @parameters.delete(:shared_secret)
+        signature = Adyen::Form.calculate_signature(@parameters)
+      end.to raise_error ArgumentError
     end
 
     it "should calculate the signature base string correctly for a recurring payment" do


### PR DESCRIPTION
This PR fixes failure of `Form#redirect_signature` on empty input by forcing the secret_key to be a string.

https://github.com/rngtng/adyen/commit/ce96438cfc89e62fef2f713fb5ac4c21ee385010

In addition in an extra commit: cleaned up whitespace chars of related files 
