### PR TITLE
Add option to configure custom payment domain

### DIFF
--- a/lib/adyen/configuration.rb
+++ b/lib/adyen/configuration.rb
@@ -40,7 +40,7 @@ class Adyen::Configuration
     LIVE_RAILS_ENVIRONMENTS.include?(rails_env) ? 'live' : 'test'
   end
 
-  # The payment flow URL that’s used to choose the payement process
+  # The payment flow page type that’s used to choose the payment process
   #
   # @example
   #   Adyen.configuration.payment_flow = :select
@@ -49,6 +49,14 @@ class Adyen::Configuration
   #
   # @return [String]
   attr_accessor :payment_flow
+
+  # The payment flow domain that’s used to choose the payment process
+  #
+  # @example
+  #   Adyen.configuration.payment_flow_domain = checkout.mydomain.com
+  #
+  # @return [String]
+  attr_accessor :payment_flow_domain
 
   # The username that’s used to authenticate for the Adyen SOAP services. It should look
   # something like ‘+ws@AndyInc.SuperShop+’

--- a/lib/adyen/form.rb
+++ b/lib/adyen/form.rb
@@ -27,22 +27,41 @@ module Adyen
     # ADYEN FORM URL
     ######################################################
 
+    # The DOMAIN of the Adyen payment system that still requires the current
+    # Adyen enviroment.
+    ACTION_DOMAIN = "%s.adyen.com"
+
     # The URL of the Adyen payment system that still requires the current
-    # Adyen enviroment and payment flow to be filled.
-    ACTION_URL = "https://%s.adyen.com/hpp/%s.shtml"
+    # domain and payment flow to be filled.
+    ACTION_URL = "https://%s/hpp/%s.shtml"
+
+    # Returns the DOMAIN of the Adyen payment system, adjusted for an Adyen environment.
+    #
+    # @param [String] environment The Adyen environment to use. This parameter can be
+    #    left out, in which case the 'current' environment will be used.
+    # @return [String] The domain of the Adyen payment system that can be used
+    #    for payment forms or redirects.
+    # @see Adyen::Form.environment
+    # @see Adyen::Form.redirect_url
+    def domain(environment = nil)
+      environment  ||= Adyen.configuration.environment
+      (Adyen.configuration.payment_flow_domain || ACTION_DOMAIN) % [environment.to_s]
+    end
 
     # Returns the URL of the Adyen payment system, adjusted for an Adyen environment.
     #
     # @param [String] environment The Adyen environment to use. This parameter can be
     #    left out, in which case the 'current' environment will be used.
+    # @param [String] payment_flow The Adyen payment type to use. This parameter can be
+    #    left out, in which case the default payment type will be used.
     # @return [String] The absolute URL of the Adyen payment system that can be used
     #    for payment forms or redirects.
     # @see Adyen::Form.environment
+    # @see Adyen::Form.domain
     # @see Adyen::Form.redirect_url
     def url(environment = nil, payment_flow = nil)
-      environment  ||= Adyen.configuration.environment
       payment_flow ||= Adyen.configuration.payment_flow
-      Adyen::Form::ACTION_URL % [environment.to_s, payment_flow.to_s]
+      Adyen::Form::ACTION_URL % [domain(environment), payment_flow.to_s]
     end
 
     ######################################################

--- a/spec/form_spec.rb
+++ b/spec/form_spec.rb
@@ -50,6 +50,17 @@ describe Adyen::Form do
       Adyen.configuration.payment_flow = :details
       Adyen::Form.url.should == 'https://test.adyen.com/hpp/details.shtml'
     end
+
+    context "with custom domain" do
+      before(:each) do
+        Adyen.configuration.payment_flow = :select
+        Adyen.configuration.payment_flow_domain = "checkout.mydomain.com"
+      end
+
+      it "should generate correct testing url" do
+        Adyen::Form.url.should == 'https://checkout.mydomain.com/hpp/select.shtml'
+      end
+    end
   end
 
   describe 'redirect signature check' do


### PR DESCRIPTION
Adyen allows to acces the payment pages via a custom domain. To cover this case, the PR adds the option to configure this domain. In case it's not given, the regular domain are used. Example:

``` ruby
  Adyen.configuration.payment_flow_domain = "checkout.mydomain.com"

  puts Adyen::Form.url # https://checkout.mydomain.com/.....
```
