### PR TITLE
Make test notifications sent from Adyen website work

### DIFF
--- a/lib/adyen/templates/notification_migration.rb
+++ b/lib/adyen/templates/notification_migration.rb
@@ -5,7 +5,7 @@ class CreateAdyenNotifications < ActiveRecord::Migration
     create_table :adyen_notifications do |t|
       t.boolean  :live,                  :null => false, :default => false
       t.string   :event_code,            :null => false, :limit => 20
-      t.string   :psp_reference,         :null => false, :limit => 30
+      t.string   :psp_reference,         :null => false, :limit => 50
       t.string   :original_reference,    :null => true
       t.string   :merchant_reference,    :null => false
       t.string   :merchant_account_code, :null => false


### PR DESCRIPTION
Currently, when testing notifications on Adyen website, Adyen sents this param:

```
"pspReference" => "testnotification_NOTIFICATIONTEST"
```

Which unfortunately does exceed the previous 30 chars limit and produces app error. This commit fixes that.
