### PR TITLE
Fix API #references call with empty recurring contracts

### DIFF
--- a/lib/adyen/api/recurring_service.rb
+++ b/lib/adyen/api/recurring_service.rb
@@ -96,7 +96,7 @@ module Adyen
         response_attrs :details, :last_known_shopper_email, :shopper_reference, :creation_date
 
         def references
-          details.map { |d| d[:recurring_detail_reference] }
+          details ? details.map { |d| d[:recurring_detail_reference] } : []
         end
 
         def params

--- a/spec/api/recurring_service_spec.rb
+++ b/spec/api/recurring_service_spec.rb
@@ -106,10 +106,15 @@ describe Adyen::API::RecurringService do
     it "returns an array with just the detail references" do
       @response.references.should == %w{ RecurringDetailReference1 RecurringDetailReference2 RecurringDetailReference3 }
     end
+  end
 
+  describe_response_from :list, LIST_EMPTY_RESPONSE, 'listRecurringDetails' do
     it "returns an empty hash when there are no details" do
-      stub_net_http(LIST_EMPTY_RESPONSE)
       @recurring.list.params.should == {}
+    end
+
+    it "returns an empty array when there are no references" do
+      @response.references.should == []
     end
   end
 


### PR DESCRIPTION
Previously, if you had no recurring contrancts and you executed a
`references` method to list IDs of those contracts, you would get this
error:

```
NoMethodError: undefined method `map' for nil:NilClass`
```

This fixes that, so you'll get an empty list instead.
