### PR TITLE
Support for Spree

### DIFF
--- a/lib/adyen/api/payment_service.rb
+++ b/lib/adyen/api/payment_service.rb
@@ -227,6 +227,11 @@ module Adyen
           super && params[:response] == self.class.request_received_value
         end
 
+        # return nil to satisfy spree
+        def authorization
+          nil
+        end
+
         def params
           @params ||= xml_querier.xpath(self.class.base_xpath) do |result|
             {


### PR DESCRIPTION
When using this gem with spree, spree tries to check if there was a authorization (https://github.com/spree/spree/blob/v1.1.3/core/app/models/spree/payment/processing.rb#L139)
and here it crashes. 
I added a authorization method that just returns nil which solves the issue. 
