### PR TITLE
Convert matchers to Nokogiri

### DIFF
--- a/lib/adyen/matchers.rb
+++ b/lib/adyen/matchers.rb
@@ -40,7 +40,7 @@ module Adyen
       end
 
       def self.check(subject, checks = {})
-        !!document(subject).xpath(build_xpath_query(checks))
+        !document(subject).xpath(build_xpath_query(checks)).empty?
       end
     end
 


### PR DESCRIPTION
This is pull request is my work on https://github.com/wvanbergen/adyen/issues/60. I just converted initializing the REXML::Document to a Nokogiri::XML.parse call and changed the check method of the RSpec matcher to return if the xpath matcher returns any nodes.

Is there a reason why REXML was used and why Nokogiri shouldn't be needed as an external dependency?

Also the matchers do not have any tests. Is that ok?
