### PR TITLE
Stop Digest::Digest deprecation warnings on ruby 2.1.0

### DIFF
--- a/lib/adyen/encoding.rb
+++ b/lib/adyen/encoding.rb
@@ -6,7 +6,7 @@ require 'zlib'
 module Adyen
   module Encoding
     def self.hmac_base64(hmac_key, message)
-      digest = OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha1'), hmac_key, message)
+      digest = OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha1'), hmac_key, message)
       Base64.encode64(digest).strip
     end
 


### PR DESCRIPTION
Usage of OpenSSL::Digest::Digest now creates deprecation warnings on ruby 2.1.0. Since the replacement OpenSSL::Digest class has existed since ruby 1.8.7 at least it seems like this would be a reasonably safe change to make. Is there anything I'm missing that this might cause problems for?
