### PR TITLE
Fix for invalid merchantSig param

### DIFF
--- a/lib/adyen/form.rb
+++ b/lib/adyen/form.rb
@@ -324,6 +324,7 @@ module Adyen
     #     using the {Adyen::Configuration#register_form_skin} method.
     # @return [true, false] Returns true only if the signature in the parameters is correct.
     def redirect_signature_check(params, shared_secret = nil)
+      params[:merchantSig].gsub!(' ', '+') if params[:merchantSig].is_a?(String) # FIX for weird encoded merchantSig containing a '+' which becomes a space in params Hash.
       params[:merchantSig] == redirect_signature(params, shared_secret)
     end
 


### PR DESCRIPTION
I've had some cases where Adyen redirects back (after a payment) with the following param string:

```
?merchantReference=someref&skinCode=somecode&shopperLocale=en&paymentMethod=payment_method&authResult=AUTHORISED&pspReference=123123123123&merchantSig=19TtXQrl/Y61HJW8+Qd/PO5Gwms=
```

The important part here is the merchantSig containing '+'. Rails (v3.2.16) turns this into "19TtXQrl/Y61HJW8 Qd/PO5Gwms=" (replacing the '+' with a space).

As I presume the merchantSig does not contain spaces we just replace them.
