### PR TITLE
Add a additional_data attr to AuthorisationResponse

### DIFF
--- a/spec/api/payment_service_spec.rb
+++ b/spec/api/payment_service_spec.rb
@@ -167,6 +167,7 @@ describe Adyen::API::PaymentService do
       :psp_reference => '9876543210987654',
       :result_code => 'Authorised',
       :auth_code => '1234',
+      :additional_data => { "cardSummary" => "1111" },
       :refusal_reason => ''
     })
 
@@ -289,6 +290,7 @@ describe Adyen::API::PaymentService do
       :psp_reference => '9876543210987654',
       :result_code => 'Authorised',
       :auth_code => '1234',
+      :additional_data => { "cardSummary" => "1111" },
       :refusal_reason => ''
     })
   end
@@ -329,6 +331,7 @@ describe Adyen::API::PaymentService do
       :psp_reference => '9876543210987654',
       :result_code => 'Authorised',
       :auth_code => '1234',
+      :additional_data => { "cardSummary" => "1111" },
       :refusal_reason => ''
     })
   end

--- a/spec/api/spec_helper.rb
+++ b/spec/api/spec_helper.rb
@@ -222,7 +222,12 @@ AUTHORISE_RESPONSE = <<EOS
   <soap:Body>
     <ns1:authoriseResponse xmlns:ns1="http://payment.services.adyen.com">
       <ns1:paymentResult>
-        <additionalData xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+        <additionalData xmlns="http://payment.services.adyen.com">
+          <entry>
+            <key xsi:type="xsd:string">cardSummary</key>
+            <value xsi:type="xsd:string">1111</value>
+          </entry>
+        </additionalData>
         <authCode xmlns="http://payment.services.adyen.com">1234</authCode>
         <dccAmount xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
         <dccSignature xmlns="http://payment.services.adyen.com" xsi:nil="true"/>


### PR DESCRIPTION
Customers might require adyen support to enable this feature where their
api return the credit card last 4 digits when doing an authorization.
Should come in handy when using client side encryption and you never
have a chance to grab the cc last 4 digits
