### PR TITLE
Better underscore <-> camelcase conversion

### DIFF
--- a/lib/adyen/util.rb
+++ b/lib/adyen/util.rb
@@ -56,15 +56,15 @@ module Adyen
     # @param [:to_s] identifier The identifier to turn to camelcase.
     # @return [String] The camelcase version of the identifier provided.
     def camelize(identifier)
-      identifier.to_s.gsub(/_+(.)/) { $1.upcase }
+      CAMELCASE_EXCEPTIONS[identifier.to_s] || identifier.to_s.gsub(/_+(.)/) { $1.upcase }
     end
 
     # Returns the underscore version of a string.
     # @param [:to_s] identifier The identifier to turn to underscore notation.
     # @return [String] The underscore version of the identifier provided.
     def underscore(identifier)
-      identifier.to_s
-        .gsub(/([A-Z]+)([A-Z])/) { "#{$1.downcase}#{$2}" }
+      UNDERSCORE_EXCEPTIONS[identifier.to_s] || identifier.to_s
+        .gsub(/([A-Z]{2,})([A-Z])/) { "#{$1.downcase}#{$2}" }
         .gsub(/(?!\A)([A-Z][a-z]*)/, '_\1')
         .downcase
     end
@@ -133,5 +133,15 @@ module Adyen
         deflatten_pair(rest, value, return_hash[key])
       end
     end
+
+    # This hash contains exceptions to the standard underscore to camelcase conversion rules.
+    CAMELCASE_EXCEPTIONS = {
+      'shopper_ip' => 'shopperIP'
+    }
+
+    # This hash contains exceptions to the standard camelcase to underscore conversion rules.
+    UNDERSCORE_EXCEPTIONS = CAMELCASE_EXCEPTIONS.invert
+
+    private_constant :CAMELCASE_EXCEPTIONS, :UNDERSCORE_EXCEPTIONS
   end
 end

--- a/test/helpers/example_server.rb
+++ b/test/helpers/example_server.rb
@@ -66,10 +66,10 @@ class Adyen::ExampleServer < Sinatra::Base
         amount: { currency: 'EUR', value: 1234 },
         reference: 'Test order #1',
         browser_info: {
-          acceptHeader: request['Accept'] || "text/html;q=0.9,*/*",
-          userAgent: request.user_agent
+          accept_header: request['Accept'] || "text/html;q=0.9,*/*",
+          user_agent: request.user_agent
         },
-        additionalData: {
+        additional_data: {
           card: {
             encrypted: {
               json: params['adyen-encrypted-data']
@@ -105,10 +105,10 @@ class Adyen::ExampleServer < Sinatra::Base
       payment_request_3d: {
         merchant_account: 'VanBergenORG',
         browser_info: {
-          acceptHeader: request['Accept'] || "text/html;q=0.9,*/*",
-          userAgent: request.user_agent
+          accept_header: request['Accept'] || "text/html;q=0.9,*/*",
+          user_agent: request.user_agent
         },
-        shopperIP: request.ip,
+        shopper_ip: request.ip,
         pa_response: params['PaRes'],
         md: params['MD'],
       }

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -32,11 +32,13 @@ class UtilTest < Minitest::Test
   def test_camelize
     assert_equal 'helloCruelWorld', Adyen::Util.camelize(:hello_cruel_world)
     assert_equal 'HelloWorld', Adyen::Util.camelize('_hello__world')
+    assert_equal 'shopperIP', Adyen::Util.camelize('shopper_ip')
   end
 
   def test_underscore
     assert_equal 'hello_cruel_world', Adyen::Util.underscore('HelloCruelWorld')
     assert_equal 'rest_api', Adyen::Util.underscore('RESTApi')
+    assert_equal 'shopper_ip', Adyen::Util.underscore('shopperIP')
   end
 
   def test_flatten
@@ -51,11 +53,11 @@ class UtilTest < Minitest::Test
     expected_hash = {
       "payment_details" => {
         "billing_address" => {
-          "street" => "Bell Street", 
-          "number" => 123, 
+          "street" => "Bell Street",
+          "number" => 123,
           "city" => "Ottawa"
-        }, 
-        "result" => "Authorized", 
+        },
+        "result" => "Authorized",
         "auth_code" => "A40B8"
       }
     }


### PR DESCRIPTION
Allows for exceptions so things like shopper_ip <-> shopperIP are supported without crazy regexen. Updated the example server to consistently use underscore identifiers.
