### PR TITLE
Implement payment modification API

### DIFF
--- a/lib/adyen/rest/client.rb
+++ b/lib/adyen/rest/client.rb
@@ -5,6 +5,7 @@ require 'adyen/rest/errors'
 require 'adyen/rest/request'
 require 'adyen/rest/response'
 require 'adyen/rest/authorise_payment'
+require 'adyen/rest/modify_payment'
 
 module Adyen
   module REST
@@ -16,6 +17,7 @@ module Adyen
     #   @return [String]
     class Client
       include AuthorisePayment
+      include ModifyPayment
 
       attr_reader :environment
 
@@ -86,7 +88,7 @@ module Adyen
         when Net::HTTPOK
           return response
         when Net::HTTPInternalServerError
-          raise Adyen::REST::ErrorResponse.new(response.body)
+          raise Adyen::REST::ResponseError.new(response.body)
         when Net::HTTPUnauthorized
           raise Adyen::REST::Error.new("Webservice credentials are incorrect")
         else

--- a/lib/adyen/rest/modify_payment.rb
+++ b/lib/adyen/rest/modify_payment.rb
@@ -1,0 +1,95 @@
+module Adyen
+  module REST
+
+    # This module implements the <b>Payment.capture</b> API to capture
+    # previously authorised payments.
+    module ModifyPayment
+      class Request < Adyen::REST::Request
+        def set_amount(currency, value)
+          self['modification_amount'] = { currency: currency, value: value }
+        end
+      end
+
+      class Response < Adyen::REST::Response
+        attr_reader :expected_response
+
+        def initialize(http_response, options = {})
+          super
+          @expected_response = options[:expects]
+        end
+
+        def received?
+          self[:response] == expected_response
+        end
+      end
+
+      # Constructs and issues a Payment.capture API call.
+      def capture_payment(attributes = {})
+        request = capture_payment_request(attributes)
+        execute_request(request)
+      end
+
+      def capture_payment_request(attributes = {})
+        Adyen::REST::ModifyPayment::Request.new('Payment.capture', attributes,
+          prefix: 'modification_request',
+          response_class: Adyen::REST::ModifyPayment::Response,
+          response_options: {
+            prefix: 'modification_result',
+            expects: '[capture-received]'
+          }
+        )
+      end
+
+      # Constructs and issues a Payment.cancel API call.
+      def cancel_payment(attributes = {})
+        request = cancel_payment_request(attributes)
+        execute_request(request)
+      end
+
+      def cancel_payment_request(attributes = {})
+        Adyen::REST::ModifyPayment::Request.new('Payment.cancel', attributes,
+          prefix: 'modification_request',
+          response_class: Adyen::REST::ModifyPayment::Response,
+          response_options: {
+            prefix: 'modification_result',
+            expects: '[cancel-received]'
+          }
+        )
+      end
+
+      # Constructs and issues a Payment.cancel API call.
+      def refund_payment(attributes = {})
+        request = refund_payment_request(attributes)
+        execute_request(request)
+      end
+
+      def refund_payment_request(attributes = {})
+        Adyen::REST::ModifyPayment::Request.new('Payment.refund', attributes,
+          prefix: 'modification_request',
+          response_class: Adyen::REST::ModifyPayment::Response,
+          response_options: {
+            prefix: 'modification_result',
+            expects: '[refund-received]'
+          }
+        )
+      end
+
+      # Constructs and issues a Payment.cancel API call.
+      def cancel_or_refund_payment(attributes = {})
+        request = cancel_or_refund_payment_request(attributes)
+        execute_request(request)
+      end
+
+      def cancel_or_refund_payment_request(attributes = {})
+        Adyen::REST::ModifyPayment::Request.new('Payment.cancelOrRefund', attributes,
+          prefix: 'modification_request',
+          response_class: Adyen::REST::ModifyPayment::Response,
+          response_options: {
+            prefix: 'modification_result',
+            expects: '[cancelOrRefund-received]'
+          }
+        )
+      end
+    end
+  end
+end

--- a/lib/adyen/rest/response.rb
+++ b/lib/adyen/rest/response.rb
@@ -39,10 +39,6 @@ module Adyen
         Integer(self[:psp_reference])
       end
 
-      def result_code
-        self[:result_code]
-      end
-
       protected
 
       def canonical_name(name)

--- a/test/functional/payment_authorisation_api_test.rb
+++ b/test/functional/payment_authorisation_api_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PaymentRestApiFunctionalTest < Minitest::Test
+class PaymentAuthorisationAPITest < Minitest::Test
   def setup
     setup_api_configuration
     @client = Adyen::REST.client
@@ -18,7 +18,7 @@ class PaymentRestApiFunctionalTest < Minitest::Test
       card: Adyen::TestCards::VISA
     )
 
-    assert_equal 'Authorised', response[:result_code]
+    assert response.authorised?
     assert response.psp_reference
   end
 
@@ -30,7 +30,7 @@ class PaymentRestApiFunctionalTest < Minitest::Test
       card: Adyen::TestCards::VISA.merge(cvc: '123')
     )
 
-    assert_equal 'Refused', response[:result_code]
+    assert response.refused?
     assert response.psp_reference
     assert response.has_attribute?(:refusal_reason)
   end
@@ -47,7 +47,7 @@ class PaymentRestApiFunctionalTest < Minitest::Test
       }
     )
 
-    assert_equal 'RedirectShopper', response.result_code
+    assert response.redirect_shopper?
     assert response.psp_reference
     assert response.has_attribute?(:md)
     assert_equal "https://test.adyen.com/hpp/3d/validate.shtml", response['issuer_url']

--- a/test/functional/payment_modification_api_test.rb
+++ b/test/functional/payment_modification_api_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class PaymentModificationAPITest < Minitest::Test
+  def setup
+    setup_api_configuration
+    @client = Adyen::REST.client
+  end
+
+  def teardown
+    @client.close
+  end
+
+  def test_capture_payment_api_request
+    response = @client.capture_payment(
+      merchant_account: 'VanBergenORG',
+      modification_amount: { currency: 'EUR', value: 1234 },
+      reference: "functional test for cancellation",
+      original_reference: 7913939284323855
+    )
+
+    assert response.received?
+    assert response.psp_reference
+  end
+
+  def test_cancel_payment_api_request
+    response = @client.cancel_payment(
+      merchant_account: 'VanBergenORG',
+      reference: "functional test for cancellation",
+      original_reference: 7913939284323855
+    )
+
+    assert response.received?
+    assert response.psp_reference
+  end
+
+  def test_refund_payment_api_request
+    response = @client.refund_payment(
+      merchant_account: 'VanBergenORG',
+      modification_amount: { currency: 'EUR', value: 1234 },
+      reference: "functional test for cancellation",
+      original_reference: 7913939284323855
+    )
+
+    assert response.received?
+    assert response.psp_reference
+  end
+
+  def test_cancel_or_refund_payment_api_request
+    response = @client.cancel_or_refund_payment(
+      merchant_account: 'VanBergenORG',
+      reference: "functional test for cancellation",
+      original_reference: 7913939284323855
+    )
+
+    assert response.received?
+    assert response.psp_reference
+  end
+end


### PR DESCRIPTION
This implements:
- capture payment
- cancel payment
- refund payment
- cancel or refund payment

Also some bugfixes and cleanup in the authorise payment API.
