### PR TITLE
Added api_response.authorised? to sinatra test server for authorise_payment_3dsecure

### DIFF
--- a/test/helpers/example_server.rb
+++ b/test/helpers/example_server.rb
@@ -100,6 +100,12 @@ class Adyen::ExampleServer < Sinatra::Base
       auth_code: api_response[:auth_code],
     }
 
-    erb :authorized
+    if api_response.authorised?
+      erb :authorized
+
+    else
+      status 400
+      body api_response[:refusal_reason]
+    end
   end
 end


### PR DESCRIPTION
Adyen documentation states for Payment.authorise3d:

````The response to this request is the same as a non-3-D Secure payment request and the resultCode will be one of Authorised, Refused or Error.`````

on the example server until then, things were made as if a fake user and password was on entered 3DS page it triggered an authorized response from it.

Thank you

PS integration tests passes locally lets see if travis CI will chop my head off this time :)
