### PR TITLE
Add merchant_account_code to uniqueness criteria

### DIFF
--- a/lib/adyen/templates/notification_migration.rb
+++ b/lib/adyen/templates/notification_migration.rb
@@ -20,7 +20,7 @@ class CreateAdyenNotifications < ActiveRecord::Migration
       t.timestamps
     end
      
-    add_index :adyen_notifications, [:psp_reference, :event_code, :success], :unique => true, :name => 'adyen_notification_uniqueness'
+    add_index :adyen_notifications, [:merchant_account_code, :psp_reference, :event_code, :success], :unique => true, :name => 'adyen_notification_uniqueness'
   end
 
   def self.down

--- a/lib/adyen/templates/notification_model.rb
+++ b/lib/adyen/templates/notification_model.rb
@@ -24,8 +24,8 @@ class AdyenNotification < ActiveRecord::Base
   validates_presence_of :psp_reference
 
   # A notification should be unique using the composed key of
-  # [:psp_reference, :event_code, :success]
-  validates_uniqueness_of :success, :scope => [:psp_reference, :event_code]
+  # [:merchant_account_code, :psp_reference, :event_code, :success]
+  validates_uniqueness_of :success, :scope => [:merchant_account_code, :psp_reference, :event_code]
 
   # Make sure we don't end up with an original_reference with an empty string
   before_validation { |notification| notification.original_reference = nil if notification.original_reference.blank? }


### PR DESCRIPTION
If you use this model in a system that receives notifications for
multiple merchant accounts, the code without this fix will only allow
one REPORT_AVAILABLE notification to be saved per report file name,
regardless of how many different reports for individual merchant
accounts are sent by Adyen.

Adyen uses a non-unique psp_reference value e.g.
`settlement_detail_report_batch_1.tsv` for REPORT_AVAILABLE
notifications that will be duplicated across merchant accounts.

I have received the following answer from Adyen support after asking
them to update the documentation at
https://docs.adyen.com/display/TD/Notification+fields:

> Hi Matt,
>
> I agree that we can make it more clear in the manual. It's unique based
> on:
>
> eventCode, pspReference, merchantAccount
>
> For all other payment related notifications where we provide a 16 digit
> reference number then it's always unique.
>
> Kind regards,
> Kevin Lobbezoo