### PR TITLE
Calculate signature for delivery address if present

### DIFF
--- a/lib/adyen/form.rb
+++ b/lib/adyen/form.rb
@@ -120,6 +120,10 @@ module Adyen
         parameters[:billing_address_sig] = calculate_billing_address_signature(parameters, shared_secret)
       end
 
+      if parameters[:delivery_address]
+        parameters[:delivery_address_sig] = calculate_delivery_address_signature(parameters, shared_secret)
+      end
+
       if parameters[:shopper]
         parameters[:shopper_sig] = calculate_shopper_signature(parameters, shared_secret)
       end
@@ -265,6 +269,16 @@ module Adyen
       end.join
     end
 
+    # Generates the string that is used to calculate the request signature. This signature
+    # is used by Adyen to check whether the request is genuinely originating from you.
+    # @param [Hash] parameters The parameters that will be included in the delivery address request.
+    # @return [String] The string for which the siganture is calculated.
+    def calculate_delivery_address_signature_string(parameters)
+      %w(street house_number_or_name city postal_code state_or_province country).map do |key|
+        parameters[key.to_sym]
+      end.join
+    end
+
     # Calculates the billing address request signature for the given billing address parameters.
     #
     # This signature is used by Adyen to check whether the request is
@@ -283,6 +297,26 @@ module Adyen
       shared_secret ||= parameters.delete(:shared_secret)
       raise ArgumentError, "Cannot calculate billing address request signature with empty shared_secret" if shared_secret.to_s.empty?
       Adyen::Util.hmac_base64(shared_secret, calculate_billing_address_signature_string(parameters[:billing_address]))
+    end
+
+    # Calculates the delivery address request signature for the given delivery address parameters.
+    #
+    # This signature is used by Adyen to check whether the request is
+    # genuinely originating from you. The resulting signature should be
+    # included in the delivery address request parameters as the +deliveryAddressSig+
+    # parameter; the shared secret should of course not be included.
+    #
+    # @param [Hash] parameters The delivery address parameters for which to calculate
+    #    the delivery address request signature.
+    # @param [String] shared_secret The shared secret to use for this signature.
+    #    It should correspond with the skin_code parameter. This parameter can be
+    #    left out if the shared_secret is included as key in the parameters.
+    # @return [String] The signature of the delivery address request
+    # @raise [ArgumentError] Thrown if shared_secret is empty
+    def calculate_delivery_address_signature(parameters, shared_secret = nil)
+      shared_secret ||= parameters.delete(:shared_secret)
+      raise ArgumentError, "Cannot calculate delivery address request signature with empty shared_secret" if shared_secret.to_s.empty?
+      Adyen::Util.hmac_base64(shared_secret, calculate_delivery_address_signature_string(parameters[:delivery_address]))
     end
 
     # shopperSig: shopper.firstName + shopper.infix + shopper.lastName + shopper.gender + shopper.dateOfBirthDayOfMonth + shopper.dateOfBirthMonth + shopper.dateOfBirthYear + shopper.telephoneNumber

--- a/test/form_test.rb
+++ b/test/form_test.rb
@@ -29,6 +29,14 @@ class FormTest < Minitest::Test
         :state_or_province    => 'Berlin',
         :country              => 'Germany',
       },
+      :delivery_address => {
+        :street               => 'Pecunialaan',
+        :house_number_or_name => '316',
+        :city                 => 'Geldrop',
+        :state_or_province    => 'None',
+        :postal_code          => '1234 AB',
+        :country              => 'Netherlands',
+      },
       :shopper => {
         :telephone_number       => '1234512345',
         :first_name             => 'John',
@@ -150,9 +158,19 @@ class FormTest < Minitest::Test
     assert_raises(ArgumentError) { Adyen::Form.calculate_billing_address_signature(@payment_attributes) } 
   end
 
-  def test_billing_address_and_shopper_signature_in_redirect_url
+  def test_delivery_address_signature
+    signature_string = Adyen::Form.calculate_delivery_address_signature_string(@payment_attributes[:delivery_address])
+    assert_equal "Pecunialaan316Geldrop1234 ABNoneNetherlands", signature_string
+    assert_equal 'g8wPEWYrDPatkGXzuQbN1++JVbE=', Adyen::Form.calculate_delivery_address_signature(@payment_attributes)
+
+    @payment_attributes.delete(:shared_secret)
+    assert_raises(ArgumentError) { Adyen::Form.calculate_delivery_address_signature(@payment_attributes) }
+  end
+
+  def test_billing_address_and_delivery_address_and_shopper_signature_in_redirect_url
     get_params = CGI.parse(URI(Adyen::Form.redirect_url(@payment_attributes)).query)
     assert_equal '5KQb7VJq4cz75cqp11JDajntCY4=', get_params['billingAddressSig'].first
+    assert_equal 'g8wPEWYrDPatkGXzuQbN1++JVbE=', get_params['deliveryAddressSig'].first
     assert_equal 'rb2GEs1kGKuLh255a3QRPBYXmsQ=', get_params['shopperSig'].first
   end  
 


### PR DESCRIPTION
For Adyen's Open Invoice payment methods, the delivery address can and sometimes has to be sent. If it is sent, it should be signed. The present PR adds support for this.