### PR TITLE
Calculate order items signature

### DIFF
--- a/lib/adyen/form.rb
+++ b/lib/adyen/form.rb
@@ -333,6 +333,19 @@ module Adyen
       Adyen::Util.hmac_base64(shared_secret, calculate_shopper_signature_string(parameters[:shopper]))
     end
 
+    def calculate_open_invoice_signature_string(merchant_sig, parameters)
+      flattened = Adyen::Util.flatten(:merchant_sig => merchant_sig, :openinvoicedata => parameters)
+      pairs = flattened.to_a.sort
+      [pairs.map(&:first).join(':'), pairs.map(&:last).join(':')].join('|')
+    end
+
+    def calculate_open_invoice_signature(parameters, shared_secret = nil)
+      shared_secret ||= parameters.delete(:shared_secret)
+      raise ArgumentError, "Cannot calculate open invoice request signature with empty shared_secret" if shared_secret.to_s.empty?
+      merchant_sig = calculate_signature(parameters, shared_secret)
+      Adyen::Util.hmac_base64(shared_secret, calculate_open_invoice_signature_string(merchant_sig, parameters[:openinvoicedata]))
+    end
+
     ######################################################
     # REDIRECT SIGNATURE CHECKING
     ######################################################

--- a/lib/adyen/form.rb
+++ b/lib/adyen/form.rb
@@ -128,6 +128,10 @@ module Adyen
         parameters[:shopper_sig] = calculate_shopper_signature(parameters, shared_secret)
       end
 
+      if parameters[:openinvoicedata]
+        parameters[:openinvoicedata][:signature] = calculate_open_invoice_signature(parameters, shared_secret)
+      end
+
       return parameters
     end
 

--- a/lib/adyen/form.rb
+++ b/lib/adyen/form.rb
@@ -336,7 +336,7 @@ module Adyen
     def calculate_open_invoice_signature_string(merchant_sig, parameters)
       flattened = Adyen::Util.flatten(:merchant_sig => merchant_sig, :openinvoicedata => parameters)
       pairs = flattened.to_a.sort
-      [pairs.map(&:first).join(':'), pairs.map(&:last).join(':')].join('|')
+      pairs.transpose.map { |it| it.join(':') }.join('|')
     end
 
     def calculate_open_invoice_signature(parameters, shared_secret = nil)

--- a/test/form_test.rb
+++ b/test/form_test.rb
@@ -222,6 +222,7 @@ class FormTest < Minitest::Test
     assert_equal '5KQb7VJq4cz75cqp11JDajntCY4=', get_params['billingAddressSig'].first
     assert_equal 'g8wPEWYrDPatkGXzuQbN1++JVbE=', get_params['deliveryAddressSig'].first
     assert_equal 'rb2GEs1kGKuLh255a3QRPBYXmsQ=', get_params['shopperSig'].first
+    assert_equal 'OI71VGB7G3vKBRrtE6Ibv+RWvYY=', get_params['openinvoicedata.signature'].first
   end  
 
   def test_redirect_signature_check


### PR DESCRIPTION
As a follow-up for #125, Adyen's open invoice also needs the signature of any openinvoicedata sent. This PR implements that signature and includes the commits for #125. I can rebase once #125 is merged.