### PR TITLE
Fix openinvoicedata signature key

### DIFF
--- a/lib/adyen/form.rb
+++ b/lib/adyen/form.rb
@@ -129,7 +129,7 @@ module Adyen
       end
 
       if parameters[:openinvoicedata]
-        parameters[:openinvoicedata][:signature] = calculate_open_invoice_signature(parameters, shared_secret)
+        parameters[:openinvoicedata][:sig] = calculate_open_invoice_signature(parameters, shared_secret)
       end
 
       return parameters

--- a/test/form_test.rb
+++ b/test/form_test.rb
@@ -228,7 +228,7 @@ class FormTest < Minitest::Test
     assert_equal '5KQb7VJq4cz75cqp11JDajntCY4=', get_params['billingAddressSig'].first
     assert_equal 'g8wPEWYrDPatkGXzuQbN1++JVbE=', get_params['deliveryAddressSig'].first
     assert_equal 'rb2GEs1kGKuLh255a3QRPBYXmsQ=', get_params['shopperSig'].first
-    assert_equal 'OI71VGB7G3vKBRrtE6Ibv+RWvYY=', get_params['openinvoicedata.signature'].first
+    assert_equal 'OI71VGB7G3vKBRrtE6Ibv+RWvYY=', get_params['openinvoicedata.sig'].first
   end  
 
   def test_redirect_signature_check


### PR DESCRIPTION
The signature key is stated incorrectly in Adyen's documentation (Adyen OpenInvoice Manual), but correctly in the example: It is 'sig', not 'signature'.