### PR TITLE
Fix additional data in authorisation response 1.6.0

### DIFF
--- a/lib/adyen/api/payment_service.rb
+++ b/lib/adyen/api/payment_service.rb
@@ -316,11 +316,14 @@ module Adyen
               results = {}
 
               xpath.map do |node|
-                key = node.text('./payment:entry/payment:key')
-                value = node.text('./payment:entry/payment:value')
-                results[key] = value unless key.empty?
-              end
+                keys = node.xpath('./payment:entry/payment:key/text()')
+                values = node.xpath('./payment:entry/payment:value/text()')
 
+                keys.map do |key|
+                  normalized_key = Adyen::Formatter::String.normalize_key(key.to_s)
+                  results[normalized_key] = values.shift.to_s
+                end
+              end
               results
             end
           end

--- a/lib/adyen/api/templates/payment_service.rb
+++ b/lib/adyen/api/templates/payment_service.rb
@@ -147,6 +147,7 @@ module Adyen
         :email     => '        <payment:shopperEmail>%s</payment:shopperEmail>',
         :ip        => '        <payment:shopperIP>%s</payment:shopperIP>',
         :statement => '        <payment:shopperStatement>%s</payment:shopperStatement>',
+        :social_security_number => '        <payment:shopper.socialSecurityNumber>%s</payment:shopper.socialSecurityNumber>'
       }
 
       # @private

--- a/lib/adyen/api/xml_querier.rb
+++ b/lib/adyen/api/xml_querier.rb
@@ -51,11 +51,15 @@ module Adyen
         end
 
         def perform_xpath(query, root_node)
-          REXML::XPath.match(root_node, query, NS)          
+          REXML::XPath.match(root_node, query, NS)
         end
 
         def stringify_nodeset(nodeset)
-          nodeset.map { |n| n.to_s }.join("")
+          if nodeset.respond_to?(:map)
+            nodeset.map { |n| n.to_s }.join("")
+          else
+            nodeset.to_s
+          end
         end
       end
 
@@ -63,7 +67,7 @@ module Adyen
       def self.default_backend
         @default_backend ||= begin
           NokogiriBackend.new
-        rescue LoadError => e
+        rescue LoadError
           REXMLBackend.new
         end
       end
@@ -85,7 +89,7 @@ module Adyen
           data
         elsif data.responds_to?(:body)
           data.body.to_s
-        else 
+        else
           data.to_s
         end
       end
@@ -131,6 +135,10 @@ module Adyen
       # @return [Array] The list of nodes wrapped in XMLQuerier instances.
       def map(&block)
         @node.map { |n| self.class.new(n, backend) }.map(&block)
+      end
+
+      def shift
+        @node.shift
       end
     end
   end

--- a/lib/adyen/formatter.rb
+++ b/lib/adyen/formatter.rb
@@ -29,5 +29,15 @@ module Adyen
         end
       end
     end
+
+    module String
+      def self.normalize_key(string)
+        if string.to_s.strip.empty?
+          raise ArgumentError, "Cannot normalize (#{string}) to key format."
+        else
+          string.gsub(/(.)([A-Z])/,'\1_\2').downcase.to_sym
+        end
+      end
+    end
   end
 end

--- a/lib/adyen/version.rb
+++ b/lib/adyen/version.rb
@@ -1,5 +1,5 @@
 module Adyen
   # Version constant for the Adyen plugin.
   # Set it & commit the change before running rake release.
-  VERSION = "1.6.0"
+  VERSION = "1.7.0"
 end

--- a/spec/api/payment_service_spec.rb
+++ b/spec/api/payment_service_spec.rb
@@ -195,7 +195,7 @@ describe Adyen::API::PaymentService do
       :psp_reference => '9876543210987654',
       :result_code => 'Authorised',
       :auth_code => '1234',
-      :additional_data => { "cardSummary" => "1111" },
+      :additional_data => { card_summary: "1111" },
       :refusal_reason => ''
     })
 
@@ -318,7 +318,7 @@ describe Adyen::API::PaymentService do
       :psp_reference => '9876543210987654',
       :result_code => 'Authorised',
       :auth_code => '1234',
-      :additional_data => { "cardSummary" => "1111" },
+      :additional_data => { card_summary: "1111" },
       :refusal_reason => ''
     })
   end
@@ -359,7 +359,7 @@ describe Adyen::API::PaymentService do
       :psp_reference => '9876543210987654',
       :result_code => 'Authorised',
       :auth_code => '1234',
-      :additional_data => { "cardSummary" => "1111" },
+      :additional_data => { card_summary: "1111" },
       :refusal_reason => ''
     })
   end


### PR DESCRIPTION
I do not know if Adyen has modified its contract of SOAP response, but additionalData field in authorisation response was coming like this:

`{"fieldOnefieldTwofieldThree" => "valueOnevalueTwovalueThree"}`

This pull request tries to fix this.