### PR TITLE
Fix billet url response in 1.6.0

### DIFF
--- a/lib/adyen/api/templates/payment_service.rb
+++ b/lib/adyen/api/templates/payment_service.rb
@@ -147,6 +147,7 @@ module Adyen
         :email     => '        <payment:shopperEmail>%s</payment:shopperEmail>',
         :ip        => '        <payment:shopperIP>%s</payment:shopperIP>',
         :statement => '        <payment:shopperStatement>%s</payment:shopperStatement>',
+        :social_security_number => '        <payment:shopper.socialSecurityNumber>%s</payment:shopper.socialSecurityNumber>'
       }
 
       # @private

--- a/lib/adyen/formatter.rb
+++ b/lib/adyen/formatter.rb
@@ -29,5 +29,15 @@ module Adyen
         end
       end
     end
+
+    module String
+      def self.normalize_key(string)
+        if string.to_s.strip.empty?
+          raise ArgumentError, "Cannot normalize (#{string}) to key format."
+        else
+          string.gsub(/(.)([A-Z])/,'\1_\2').downcase.to_sym
+        end
+      end
+    end
   end
 end

--- a/lib/adyen/version.rb
+++ b/lib/adyen/version.rb
@@ -1,5 +1,5 @@
 module Adyen
   # Version constant for the Adyen plugin.
   # Set it & commit the change before running rake release.
-  VERSION = "1.6.0"
+  VERSION = "1.7.0"
 end

--- a/spec/api/payment_service_spec.rb
+++ b/spec/api/payment_service_spec.rb
@@ -166,7 +166,8 @@ describe Adyen::API::PaymentService do
     it_should_return_params_for_each_xml_backend({
       :psp_reference => "8814038837489129",
       :result_code => "Received",
-      :billet_url => "https://test.adyen.com/hpp/generationBoleto.shtml?data=AgABAQBdYDe9OqdseA79Rfexm2Lz8fRQ1bWqkLhBCf1fHhQEif7bsRKi0otq%2B1ekMAdMIZUiVXeR3QFrAOA8Zy4tpiNLhkMq6f7W2zFqYhVWrByqxQnbQTYuX2FWI7tsu7Vb0MnyOvFfFdFtaxzImZYCli%2BMrqaAJ5HI9ap3egeqBQIsRI%2Fj0zWsu2EGN16lGbwFOLyxl%2By0Pc5jazTo8rnBA7OVPGDIu7Qt%2F2DYIMcB6PXou5W3aJoTC4SldhNdobVqgWUtES8NsWdOYbLGa6I%2BjSwEFXvxyTXwtw4J2E%2BE7ux1UhBiZRj66lMbcvaYlfnR2xWbA%2BKmdLrVvuXTroEHKQ%2B1C%2FuyGuiOk3SmGq6TMgOyCEt%2BmG%2Bq6z5jDi%2BnYLtlLQU4ccMOujgWMfGkViC%2FXDUlqYjKbn8NHwPwoPcelpf1zCDCe%2Fvu6NBTVQbEXbE0oV0j2MT1tLlMdf08iUsDThuQ3MlJbE8VbTMlttOFqoyXhBjepQ42C1eXfswSz1gsZlHanBCTiw1pB69vkvfWPf5IdUSx1cpEr9LJ9PSz%2FeHxEhq%2B8ZdWzrybXqRbEl2mUjLeyhMNuiE%3D"
+      :billet_url => "https://test.adyen.com/hpp/generationBoleto.shtml?data=AgABAQBdYDe9OqdseA79Rfexm2Lz8fRQ1bWqkLhBCf1fHhQEif7bsRKi0otq%2B1ekMAdMIZUiVXeR3QFrAOA8Zy4tpiNLhkMq6f7W2zFqYhVWrByqxQnbQTYuX2FWI7tsu7Vb0MnyOvFfFdFtaxzImZYCli%2BMrqaAJ5HI9ap3egeqBQIsRI%2Fj0zWsu2EGN16lGbwFOLyxl%2By0Pc5jazTo8rnBA7OVPGDIu7Qt%2F2DYIMcB6PXou5W3aJoTC4SldhNdobVqgWUtES8NsWdOYbLGa6I%2BjSwEFXvxyTXwtw4J2E%2BE7ux1UhBiZRj66lMbcvaYlfnR2xWbA%2BKmdLrVvuXTroEHKQ%2B1C%2FuyGuiOk3SmGq6TMgOyCEt%2BmG%2Bq6z5jDi%2BnYLtlLQU4ccMOujgWMfGkViC%2FXDUlqYjKbn8NHwPwoPcelpf1zCDCe%2Fvu6NBTVQbEXbE0oV0j2MT1tLlMdf08iUsDThuQ3MlJbE8VbTMlttOFqoyXhBjepQ42C1eXfswSz1gsZlHanBCTiw1pB69vkvfWPf5IdUSx1cpEr9LJ9PSz%2FeHxEhq%2B8ZdWzrybXqRbEl2mUjLeyhMNuiE%3D",
+      :additional_data => {:url=>"https://test.adyen.com/hpp/generationBoleto.shtml?data=AgABAQBdYDe9OqdseA79Rfexm2Lz8fRQ1bWqkLhBCf1fHhQEif7bsRKi0otq%2B1ekMAdMIZUiVXeR3QFrAOA8Zy4tpiNLhkMq6f7W2zFqYhVWrByqxQnbQTYuX2FWI7tsu7Vb0MnyOvFfFdFtaxzImZYCli%2BMrqaAJ5HI9ap3egeqBQIsRI%2Fj0zWsu2EGN16lGbwFOLyxl%2By0Pc5jazTo8rnBA7OVPGDIu7Qt%2F2DYIMcB6PXou5W3aJoTC4SldhNdobVqgWUtES8NsWdOYbLGa6I%2BjSwEFXvxyTXwtw4J2E%2BE7ux1UhBiZRj66lMbcvaYlfnR2xWbA%2BKmdLrVvuXTroEHKQ%2B1C%2FuyGuiOk3SmGq6TMgOyCEt%2BmG%2Bq6z5jDi%2BnYLtlLQU4ccMOujgWMfGkViC%2FXDUlqYjKbn8NHwPwoPcelpf1zCDCe%2Fvu6NBTVQbEXbE0oV0j2MT1tLlMdf08iUsDThuQ3MlJbE8VbTMlttOFqoyXhBjepQ42C1eXfswSz1gsZlHanBCTiw1pB69vkvfWPf5IdUSx1cpEr9LJ9PSz%2FeHxEhq%2B8ZdWzrybXqRbEl2mUjLeyhMNuiE%3D", :data=>"AgABAQBdYDe9OqdseA79Rfexm2Lz8fRQ1bWqkLhBCf1fHhQEif7bsRKi0otq+1ekMAdMIZUiVXeR3QFrAOA8Zy4tpiNLhkMq6f7W2zFqYhVWrByqxQnbQTYuX2FWI7tsu7Vb0MnyOvFfFdFtaxzImZYCli+MrqaAJ5HI9ap3egeqBQIsRI/j0zWsu2EGN16lGbwFOLyxl+y0Pc5jazTo8rnBA7OVPGDIu7Qt/2DYIMcB6PXou5W3aJoTC4SldhNdobVqgWUtES8NsWdOYbLGa6I+jSwEFXvxyTXwtw4J2E+E7ux1UhBiZRj66lMbcvaYlfnR2xWbA+KmdLrVvuXTroEHKQ+1C/uyGuiOk3SmGq6TMgOyCEt+mG+q6z5jDi+nYLtlLQU4ccMOujgWMfGkViC/XDUlqYjKbn8NHwPwoPcelpf1zCDCe/vu6NBTVQbEXbE0oV0j2MT1tLlMdf08iUsDThuQ3MlJbE8VbTMlttOFqoyXhBjepQ42C1eXfswSz1gsZlHanBCTiw1pB69vkvfWPf5IdUSx1cpEr9LJ9PSz/eHxEhq+8ZdWzrybXqRbEl2mUjLeyhMNuiE=", :expiration_date=>"2014-07-17", :due_date=>"2014-07-02"}
     })
 
     describe "with a received billet" do
@@ -180,7 +181,8 @@ describe Adyen::API::PaymentService do
     it_should_return_params_for_each_xml_backend({
       :psp_reference => "8514038928235061",
       :result_code => "Refused",
-      :billet_url => ""
+      :billet_url => "",
+      :additional_data => {}
     })
 
     describe "with a received billet" do


### PR DESCRIPTION
This PR fix BilletResponse :billet_url field value, which is getting value from :issuerCountry.

Also, adds :additional_data to BilletResponse with all fields coming from Adyen response.