### PR TITLE
Making HMAC Signature generic

### DIFF
--- a/lib/adyen.rb
+++ b/lib/adyen.rb
@@ -27,8 +27,10 @@ require 'adyen/version'
 require 'adyen/configuration'
 require 'adyen/util'
 require 'adyen/hpp/signature'
+require 'adyen/rest/signature'
 require 'adyen/form'
 require 'adyen/api'
 require 'adyen/rest'
+require 'adyen/signature'
 
 require 'adyen/railtie' if defined?(::Rails) && ::Rails::VERSION::MAJOR >= 3

--- a/lib/adyen/hpp/signature.rb
+++ b/lib/adyen/hpp/signature.rb
@@ -1,6 +1,3 @@
-require 'openssl'
-require 'base64'
-
 module Adyen
   module HPP
     # The Signature module can sign and verify HMAC SHA-256 signatures for Hosted Payment Pages
@@ -8,15 +5,13 @@ module Adyen
       extend self
 
       # Sign the parameters with the given shared secret
-      # @param [Hash] params The set of parameters to sign
+      # @param [Hash] params The set of parameters to sign.
       # @param [String] shared_secret The shared secret for signing/verification. Can also be sent in the
       #   params hash with the `sharedSecret` key.
       # @return [Hash] params The params that were passed in plus a new `merchantSig` param
       def sign(params, shared_secret = nil)
-        shared_secret ||= params.delete['sharedSecret']
-        raise ArgumentError, "Cannot verify a signature without a shared secret" unless shared_secret
-        sig = OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), Array(shared_secret).pack("H*"), string_to_sign(params))
-        params.merge('merchantSig' => Base64.encode64(sig).strip)
+        params["sharedSecret"] ||= shared_secret
+        params.merge('merchantSig' => Adyen::Signature.sign(params))
       end
 
       # Verify the parameters with the given shared secret
@@ -26,40 +21,10 @@ module Adyen
       #   params hash with the `sharedSecret` key.
       # @return [Boolean] true if the `merchantSig` in the params matches our calculated signature
       def verify(params, shared_secret = nil)
+        params["sharedSecret"] ||= shared_secret
         their_sig = params.delete('merchantSig')
         raise ArgumentError, "params must include 'merchantSig' for verification" if their_sig.empty?
-        our_sig = sign(params, shared_secret)['merchantSig']
-        secure_compare(their_sig, our_sig)
-      end
-
-      private
-
-      def string_to_sign(params)
-        (sorted_keys(params) + sorted_values(params)).map{ |el| escape_value(el) }.join(':')
-      end
-
-      def sorted_keys(hash)
-        hash.sort.map{ |el| el[0] }
-      end
-
-      def sorted_values(hash)
-        hash.sort.map{ |el| el[1] }
-      end
-
-      def escape_value(value)
-        value.gsub(':', '\\:').gsub('\\', '\\\\')
-      end
-
-      # Constant-time compare for two fixed-length strings
-      # Stolen from https://github.com/rails/rails/commit/c8c660002f4b0e9606de96325f20b95248b6ff2d
-      def secure_compare(a, b)
-        return false unless a.bytesize == b.bytesize
-
-        l = a.unpack "C#{a.bytesize}"
-
-        res = 0
-        b.each_byte { |byte| res |= byte ^ l.shift }
-        res == 0
+        Adyen::Signature.verify(params, their_sig)
       end
     end
   end

--- a/lib/adyen/rest/signature.rb
+++ b/lib/adyen/rest/signature.rb
@@ -1,0 +1,25 @@
+module Adyen
+  module REST
+    # The Signature module can sign and verify HMAC SHA-256 signatures for API
+    module Signature
+      extend self
+
+      # Sign the parameters with the given shared secret
+      # @param [Hash] params The set of parameters to sign. Should sent `sharedSecret` to sign.
+      # @return [String] signature from parameters
+      def sign(params)
+        Adyen::Signature.sign(params, :rest)
+      end
+
+      # Verify the parameters with the given shared secret
+      # @param [Hash] params The set of parameters to verify.
+      # Should include `sharedSecret` param to sign and the `hmacSignature` param to compare with the signature calculated
+      # @return [Boolean] true if the `hmacSignature` in the params matches our calculated signature
+      def verify(params)
+        their_sig = params.delete('hmacSignature')
+        raise ArgumentError, "params must include 'hmacSignature' for verification" if their_sig.empty?
+        Adyen::Signature.verify(params, their_sig, :rest)
+      end
+    end
+  end
+end

--- a/lib/adyen/signature.rb
+++ b/lib/adyen/signature.rb
@@ -1,0 +1,76 @@
+require 'openssl'
+require 'base64'
+
+module Adyen
+  # The Signature module generic to sign and verify HMAC SHA-256 signatures
+  module Signature
+    extend self
+
+    # Sign the parameters with the given shared secret
+    # @param [Hash] params The set of parameters to verify. Must include a `shared_secret` param for signing/verification
+    #
+    # @param [String] type The type to sign (:hpp or :rest). Default is :hpp
+    # @return [String] The signature
+    def sign(params, type = :hpp)
+      shared_secret = params.delete('sharedSecret')
+      raise ArgumentError, 'Cannot sign without a shared secret' if shared_secret.nil?
+      sig = OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), Array(shared_secret).pack("H*"), string_to_sign(params, type))
+      Base64.encode64(sig).strip
+    end
+
+    # Compare a signature calculated with anoter HMAC Signature
+    # @param [Hash] params The set of parameters to verify. Must include a `shared_secret`
+    #   param for signing/verification
+    # @param [String] hmacSignature will be compared to the signature calculated.
+    # @return [Boolean] true if the `hmacSignature` matches our calculated signature
+    def verify(params, hmacSignature, type = :hpp)
+      raise ArgumentError,"hmacSignature cannot be empty for verification" if hmacSignature.empty?
+      our_sig = sign(params, type)
+      secure_compare(hmacSignature, our_sig)
+    end
+
+    private
+
+    def string_to_sign(params, type)
+      string = ''
+      if type == :hpp
+        string = sorted_keys(params) + sorted_values(params)
+      elsif type == :rest
+        keys = %w(pspReference originalReference merchantAccountCode merchantReference value currency eventCode success)
+        string = sorted_values(params, keys)
+      else
+        raise NotImplementedError, 'Type sign not implemented'
+      end
+
+      string.map{ |el| escape_value(el) }.join(':')
+    end
+
+    def sorted_keys(hash, keys_to_sort = nil)
+      hash.sort.map{ |el| el[0] }
+    end
+
+    def sorted_values(hash, keys_to_sort = nil)
+      if keys_to_sort.is_a? Array
+        keys_to_sort.map { |key| hash[key] }
+      else
+        hash.sort.map{ |el| el[1] }
+      end
+    end
+
+    def escape_value(value)
+      value.gsub(':', '\\:').gsub('\\', '\\\\')
+    end
+
+    # Constant-time compare for two fixed-length strings
+    # Stolen from https://github.com/rails/rails/commit/c8c660002f4b0e9606de96325f20b95248b6ff2d
+    def secure_compare(a, b)
+      return false unless a.bytesize == b.bytesize
+
+      l = a.unpack "C#{a.bytesize}"
+
+      res = 0
+      b.each_byte { |byte| res |= byte ^ l.shift }
+      res == 0
+    end
+  end
+end

--- a/test/rest/signature_test.rb
+++ b/test/rest/signature_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class SignatureTest < Minitest::Test
+  def setup
+    # values from https://docs.adyen.com/pages/viewpage.action?pageId=5376964
+
+    @expected_sig = 'S+5bAYKLd+L2A07Pal0pG/qBarnInaIe709YNzNcHOA='
+
+    @raw_params = {
+      'hmacSignature' => @expected_sig,
+      'pspReference' => '7914073251449896',
+      'originalReference' => '',
+      'eventCode' => 'AUTHORISATION',
+      'merchantAccountCode' => 'TestMerchant',
+      'merchantReference' => 'TestPayment-1407325143704',
+      'success' => 'true',
+      'value' => '8650',
+      'currency' => 'EUR',
+      'sharedSecret' => '009E9E92268087AAD241638D3325201AFC8AAE6F3DCD369B6D32E87129FFAB10'
+    }
+  end
+
+  def test_sign
+    assert_equal @expected_sig, Adyen::REST::Signature.sign(@raw_params)
+  end
+
+  def test_verify_succeeds_with_same_secret
+    assert_equal true, Adyen::REST::Signature.verify(@raw_params)
+  end
+
+  def test_verification_fails_with_different_secret
+    params = @raw_params.merge('hmacSignature' => '123')
+    assert_equal false, Adyen::REST::Signature.verify(params)
+  end
+end

--- a/test/signature_test.rb
+++ b/test/signature_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class SignatureTest < Minitest::Test
+  # HPP Signature
+  def hpp_raw_params
+    {
+      'merchantAccount' => 'TestMerchant',
+      'currencyCode' => 'EUR',
+      'paymentAmount' => '199',
+      'sessionValidity' => '2015-06-25T10:31:06Z',
+      'shipBeforeDate' => '2015-07-01',
+      'shopperLocale' => 'en_GB',
+      'merchantReference' => 'SKINTEST-1435226439255',
+      'skinCode' => 'X7hsNDWp',
+      'sharedSecret' => hpp_shared_secret
+    }
+  end
+
+  def hpp_expected_sig
+    'GJ1asjR5VmkvihDJxCd8yE2DGYOKwWwJCBiV3R51NFg='
+  end
+
+  def hpp_shared_secret
+    '4468D9782DEF54FCD706C9100C71EC43932B1EBC2ACF6BA0560C05AAA7550C48'
+  end
+
+  def test_hpp_sign
+    signed_params = Adyen::Signature.sign(hpp_raw_params)
+    assert_equal hpp_expected_sig, signed_params
+  end
+
+  def test_hpp_verify_succeeds_with_same_secret
+    assert_equal true, Adyen::Signature.verify(hpp_raw_params, hpp_expected_sig)
+  end
+
+  def test_hpp_verification_fails_with_different_secret
+    assert_equal false, Adyen::Signature.verify(hpp_raw_params, '1234')
+  end
+
+  # Rest Signature
+  def rest_raw_params
+    {
+      'pspReference' => '7914073251449896',
+      'originalReference' => '',
+      'eventCode' => 'AUTHORISATION',
+      'merchantAccountCode' => 'TestMerchant',
+      'merchantReference' => 'TestPayment-1407325143704',
+      'success' => 'true',
+      'value' => '8650',
+      'currency' => 'EUR',
+      'sharedSecret' => rest_shared_secret
+    }
+  end
+
+  def rest_expected_sig
+    'S+5bAYKLd+L2A07Pal0pG/qBarnInaIe709YNzNcHOA='
+  end
+
+  def rest_shared_secret
+    '009E9E92268087AAD241638D3325201AFC8AAE6F3DCD369B6D32E87129FFAB10'
+  end
+
+  def test_rest_sign
+    signed_params = Adyen::Signature.sign(rest_raw_params, :rest)
+    assert_equal rest_expected_sig, signed_params
+  end
+
+  def test_rest_verify_succeeds_with_same_secret
+    assert_equal true, Adyen::Signature.verify(rest_raw_params, rest_expected_sig, :rest)
+  end
+
+  def test_rest_verification_fails_with_different_secret
+    assert_equal false, Adyen::Signature.verify(rest_raw_params, '1234', :rest)
+  end
+end


### PR DESCRIPTION
About #134, I did a generic class for hmac signature. To sign notifications responses  when use Adyen API.

But, I'm not sure if the 'new' documentation it's rigth..