### PR TITLE
Implement payouts

### DIFF
--- a/lib/adyen/configuration.rb
+++ b/lib/adyen/configuration.rb
@@ -41,6 +41,10 @@ class Adyen::Configuration
     LIVE_RAILS_ENVIRONMENTS.include?(rails_env) ? 'live' : 'test'
   end
 
+
+  # TODO
+  attr_accessor :merchant_specific_endpoint
+
   # The payment flow page type that’s used to choose the payment process
   #
   # @example

--- a/lib/adyen/configuration.rb
+++ b/lib/adyen/configuration.rb
@@ -110,28 +110,6 @@ class Adyen::Configuration
   # @return [String]
   attr_accessor :ipn_password
 
-  # The username that’s used to submit payouts. It should look
-  # something like ‘storePayout@AndyInc.SuperShop+’
-  #
-  # @return [String]
-  attr_accessor :payout_store_username
-
-  # Password used to store payout together with '+payout_review_username+' configuration attribute.
-  #
-  # @return [String]
-  attr_accessor :payout_store_password
-
-  # The username that’s used to review payouts. It should look
-  # something like reviewPayout@AndyInc.SuperShop+’
-  #
-  # @return [String]
-  attr_accessor :payout_review_username
-
-  # Password used to review payout together with '+payout_review_username+' configuration attribute.
-  #
-  # @return [String]
-  attr_accessor :payout_review_password
-
   ######################################################
   # SKINS
   ######################################################

--- a/lib/adyen/configuration.rb
+++ b/lib/adyen/configuration.rb
@@ -110,6 +110,28 @@ class Adyen::Configuration
   # @return [String]
   attr_accessor :ipn_password
 
+  # The username that’s used to submit payouts. It should look
+  # something like ‘storePayout@AndyInc.SuperShop+’
+  #
+  # @return [String]
+  attr_accessor :payout_store_username
+
+  # Password used to store payout together with '+payout_review_username+' configuration attribute.
+  #
+  # @return [String]
+  attr_accessor :payout_store_password
+
+  # The username that’s used to review payouts. It should look
+  # something like reviewPayout@AndyInc.SuperShop+’
+  #
+  # @return [String]
+  attr_accessor :payout_review_username
+
+  # Password used to review payout together with '+payout_review_username+' configuration attribute.
+  #
+  # @return [String]
+  attr_accessor :payout_review_password
+
   ######################################################
   # SKINS
   ######################################################

--- a/lib/adyen/rest.rb
+++ b/lib/adyen/rest.rb
@@ -45,7 +45,8 @@ module Adyen
       Adyen::REST::Client.new(
         Adyen.configuration.environment,
         Adyen.configuration.api_username,
-        Adyen.configuration.api_password
+        Adyen.configuration.api_password,
+        Adyen.configuration.merchant_specific_endpoint
       )
     end
 

--- a/lib/adyen/rest.rb
+++ b/lib/adyen/rest.rb
@@ -45,8 +45,7 @@ module Adyen
       Adyen::REST::Client.new(
         Adyen.configuration.environment,
         Adyen.configuration.api_username,
-        Adyen.configuration.api_password,
-        Adyen.configuration.default_api_params
+        Adyen.configuration.api_password
       )
     end
 

--- a/lib/adyen/rest.rb
+++ b/lib/adyen/rest.rb
@@ -45,7 +45,8 @@ module Adyen
       Adyen::REST::Client.new(
         Adyen.configuration.environment,
         Adyen.configuration.api_username,
-        Adyen.configuration.api_password
+        Adyen.configuration.api_password,
+        Adyen.configuration.default_api_params
       )
     end
 

--- a/lib/adyen/rest/authorise_payment.rb
+++ b/lib/adyen/rest/authorise_payment.rb
@@ -87,9 +87,7 @@ module Adyen
       # @see #authorise_payment
       def authorise_payment_request(attributes = {})
         Adyen::REST::AuthorisePayment::Request.new('Payment.authorise', attributes,
-            prefix: 'payment_request',
-            response_class: Adyen::REST::AuthorisePayment::Response,
-            response_options: { prefix: 'payment_result' })
+            response_class: Adyen::REST::AuthorisePayment::Response)
       end
 
       # Sends an authorise payment request to Adyen's webservice.
@@ -117,9 +115,7 @@ module Adyen
       # @see Adyen::REST::AuthorisePayment::Response#authorised?
       def authorise_payment_3dsecure_request(attributes = {})
         Adyen::REST::AuthorisePayment::Request.new('Payment.authorise3d', attributes,
-            prefix: 'payment_request_3d',
-            response_class: Adyen::REST::AuthorisePayment::Response,
-            response_options: { prefix: 'payment_result' })
+            response_class: Adyen::REST::AuthorisePayment::Response)
       end
 
       # Sends a 3Dsecure-enabled authorise payment request to Adyen's webservice.
@@ -145,9 +141,7 @@ module Adyen
       # @see #authorise_recurring_payment
       def authorise_recurring_payment_request(attributes={})
         Adyen::REST::AuthoriseRecurringPayment::Request.new('Payment.authorise', attributes,
-            prefix: 'payment_request',
-            response_class: Adyen::REST::AuthorisePayment::Response,
-            response_options: { prefix: 'payment_result' })
+            response_class: Adyen::REST::AuthorisePayment::Response)
       end
 
       # Sends an authorise recurring payment request to Adyen's webservice.
@@ -168,9 +162,7 @@ module Adyen
       # @see #authorise_recurring_payment
       def reauthorise_recurring_payment_request(attributes={})
         Adyen::REST::ReauthoriseRecurringPayment::Request.new('Payment.authorise', attributes,
-            prefix: 'payment_request',
-            response_class: Adyen::REST::AuthorisePayment::Response,
-            response_options: { prefix: 'payment_result' })
+            response_class: Adyen::REST::AuthorisePayment::Response)
       end
 
       # Sends an authorise recurring payment request to Adyen's webservice.
@@ -201,7 +193,7 @@ module Adyen
             :card_number => "card.number"
           }
 
-          map_response_list("recurringDetailsResult.details", mapped_attributes)
+          map_response_list("details", mapped_attributes)
         end
 
         # Returns a list of recurring details references
@@ -217,9 +209,7 @@ module Adyen
       # @see #list_recurring_details
       def list_recurring_details_request(attributes = {})
         Adyen::REST::ListRecurringDetailsPayment::Request.new('Recurring.listRecurringDetails', attributes,
-            prefix: 'recurring_details_request',
-            response_class: Adyen::REST::AuthorisePayment::ListRecurringDetailsResponse,
-            response_options: { prefix: 'recurring_details_result' })
+            response_class: Adyen::REST::AuthorisePayment::ListRecurringDetailsResponse)
       end
 
       # Sends an list recurring details request to Adyen's webservice.

--- a/lib/adyen/rest/authorise_recurring_payment.rb
+++ b/lib/adyen/rest/authorise_recurring_payment.rb
@@ -8,9 +8,9 @@ module Adyen
         def initialize(action, attributes, options)
           attributes[:recurring] ||= { contract: 'RECURRING' }
           super(action, attributes, options)
-          @required_attributes += ['paymentRequest.shopperEmail',
-            'paymentRequest.recurring.contract',
-            'paymentRequest.shopperReference',
+          @required_attributes += ['shopperEmail',
+            'recurring.contract',
+            'shopperReference',
           ]
         end
       end
@@ -23,10 +23,10 @@ module Adyen
           attributes[:shopper_interaction] ||= 'ContAuth'
           attributes[:selected_recurring_detail_reference] ||= 'LATEST'
           super(action, attributes, options)
-          @required_attributes += ['paymentRequest.shopperEmail',
-            'paymentRequest.shopperReference',
-            'paymentRequest.recurring.contract',
-            'paymentRequest.shopperInteraction'
+          @required_attributes += ['shopperEmail',
+            'shopperReference',
+            'recurring.contract',
+            'shopperInteraction'
           ]
         end
       end
@@ -37,9 +37,8 @@ module Adyen
         def initialize(action, attributes, options)
           attributes[:recurring] ||= { contract: 'RECURRING' }
           super(action, attributes, options)
-          @required_attributes += ['recurringDetailsRequest.merchantAccount',
-            'recurringDetailsRequest.recurring.contract',
-            'recurringDetailsRequest.shopperReference']
+          @required_attributes += ['recurring.contract',
+            'shopperReference']
         end
       end
     end

--- a/lib/adyen/rest/client.rb
+++ b/lib/adyen/rest/client.rb
@@ -22,15 +22,16 @@ module Adyen
       include ModifyPayment
       include Payout
 
-      attr_reader :environment
+      attr_reader :environment, :merchant
 
       # @param environment [String] The Adyen environment to interface with. Either
       #   <tt>'live'</tt> or <tt>'test'</tt>.
       # @param username [String] The webservice username, e.g. <tt>ws@Company.Account</tt>
       # @param password [String] The password associated with the username
+      # @param merchant [String]
       # @param default_api_params [Hash] Default arguments that will be used for every API call
-      def initialize(environment, username, password)
-        @environment, @username, @password = environment, username, password
+      def initialize(environment, username, password, merchant = nil)
+        @environment, @username, @password, @merchant = environment, username, password, merchant
       end
 
       # Closes the client.
@@ -114,12 +115,18 @@ module Adyen
       # The endpoint URI for this client.
       # @return [URI] The endpoint to use for the environment.
       def endpoint
-        @endpoint ||= URI(ENDPOINT % [environment])
+        @endpoint ||= if merchant && environment.to_sym == :live
+          URI(ENDPOINT_MERCHANT_SPECIFIC % [merchant])
+        else
+          URI(ENDPOINT % [environment])
+        end
       end
 
       # @see Adyen::REST::Client#endpoint
       ENDPOINT = 'https://pal-%s.adyen.com/'
-      private_constant :ENDPOINT
+      ENDPOINT_MERCHANT_SPECIFIC = 'https://%s.pal-live.adyenpayments.com'
+
+      private_constant :ENDPOINT, :ENDPOINT_MERCHANT_SPECIFIC
     end
   end
 end

--- a/lib/adyen/rest/client.rb
+++ b/lib/adyen/rest/client.rb
@@ -29,8 +29,8 @@ module Adyen
       # @param username [String] The webservice username, e.g. <tt>ws@Company.Account</tt>
       # @param password [String] The password associated with the username
       # @param default_api_params [Hash] Default arguments that will be used for every API call
-      def initialize(environment, username, password, default_api_params = {})
-        @environment, @username, @password, @default_api_params = environment, username, password, default_api_params
+      def initialize(environment, username, password)
+        @environment, @username, @password = environment, username, password
       end
 
       # Closes the client.
@@ -100,7 +100,7 @@ module Adyen
       def execute_http_request(request)
         http_request = Net::HTTP::Post.new(@endpoint.path)
         http_request.basic_auth(@username, @password)
-        http_request.set_form_data(form_data(request))
+        http_request.set_form_data(request.form_data)
 
         case response = http.request(http_request)
         when Net::HTTPOK
@@ -121,12 +121,6 @@ module Adyen
         @endpoint
       end
 
-      # @return [Hash] form_data
-      def form_data(request)
-        # Make sure default_api_params are camelCase
-        Adyen::Util.flatten(@default_api_params)
-          .merge(request.form_data)
-      end
 
       # @see Adyen::REST::Client#endpoint
       ENDPOINT = 'https://pal-%s.adyen.com/pal/servlet/%s'

--- a/lib/adyen/rest/client.rb
+++ b/lib/adyen/rest/client.rb
@@ -104,12 +104,10 @@ module Adyen
         case response = http.request(http_request)
         when Net::HTTPOK
           return response
-        when Net::HTTPInternalServerError
-          raise Adyen::REST::ResponseError.new(response.body)
         when Net::HTTPUnauthorized
-          raise Adyen::REST::Error.new("Webservice credentials are incorrect")
+          raise Adyen::REST::Error.new('401 (Unauthorized) - Webservice credentials are incorrect')
         else
-          raise Adyen::REST::Error.new("Unexpected HTTP response code: #{response.code} | response body: #{response.body}")
+          raise Adyen::REST::ResponseError.new(response)
         end
       end
 

--- a/lib/adyen/rest/client.rb
+++ b/lib/adyen/rest/client.rb
@@ -7,6 +7,7 @@ require 'adyen/rest/response'
 require 'adyen/rest/authorise_payment'
 require 'adyen/rest/authorise_recurring_payment'
 require 'adyen/rest/modify_payment'
+require 'adyen/rest/payout'
 
 module Adyen
   module REST
@@ -19,6 +20,7 @@ module Adyen
     class Client
       include AuthorisePayment
       include ModifyPayment
+      include Payout
 
       attr_reader :environment
 

--- a/lib/adyen/rest/client.rb
+++ b/lib/adyen/rest/client.rb
@@ -67,8 +67,8 @@ module Adyen
       #
       # @return [Net::HTTP] The underlying Net::HTTP instance the client uses to perform HTTP request.
       def http
-        @http ||= Net::HTTP.new(@endpoint.host, @endpoint.port).tap do |http|
-          http.use_ssl = @endpoint.scheme == 'https'
+        @http ||= Net::HTTP.new(endpoint.host, endpoint.port).tap do |http|
+          http.use_ssl = endpoint.scheme == 'https'
         end
       end
 
@@ -84,7 +84,6 @@ module Adyen
       #   of  executing the underlying HTTP request.
       def execute_request(request)
         request.validate!
-        set_endpoint(request.resource)
         http_response = execute_http_request(request)
         request.build_response(http_response)
       end
@@ -98,7 +97,7 @@ module Adyen
       # @see #http Use the <tt>http</tt> method to set options on the underlying
       #   <tt>Net::HTTP</tt> object, like timeouts.
       def execute_http_request(request)
-        http_request = Net::HTTP::Post.new(@endpoint.path)
+        http_request = Net::HTTP::Post.new(request.path)
         http_request.basic_auth(@username, @password)
         http_request.set_form_data(request.form_data)
 
@@ -114,16 +113,14 @@ module Adyen
         end
       end
 
-      # Set the endpoint URI for this client.
+      # The endpoint URI for this client.
       # @return [URI] The endpoint to use for the environment.
-      def set_endpoint(resource)
-        @endpoint = URI(ENDPOINT % [environment, resource])
-        @endpoint
+      def endpoint
+        @endpoint ||= URI(ENDPOINT % [environment])
       end
 
-
       # @see Adyen::REST::Client#endpoint
-      ENDPOINT = 'https://pal-%s.adyen.com/pal/servlet/%s'
+      ENDPOINT = 'https://pal-%s.adyen.com/'
       private_constant :ENDPOINT
     end
   end

--- a/lib/adyen/rest/errors.rb
+++ b/lib/adyen/rest/errors.rb
@@ -9,9 +9,6 @@ module Adyen
     class RequestValidationFailed < Adyen::REST::Error
     end
 
-    class RequiredParameterMissing < Adyen::REST::Error
-    end
-
     # Exception class for error responses from the Adyen API.
     #
     # @!attribute category

--- a/lib/adyen/rest/errors.rb
+++ b/lib/adyen/rest/errors.rb
@@ -9,6 +9,9 @@ module Adyen
     class RequestValidationFailed < Adyen::REST::Error
     end
 
+    class RequiredParameterMissing < Adyen::REST::Error
+    end
+
     # Exception class for error responses from the Adyen API.
     #
     # @!attribute category

--- a/lib/adyen/rest/modify_payment.rb
+++ b/lib/adyen/rest/modify_payment.rb
@@ -33,10 +33,8 @@ module Adyen
 
       def capture_payment_request(attributes = {})
         Adyen::REST::ModifyPayment::Request.new('Payment.capture', attributes,
-          prefix: 'modification_request',
           response_class: Adyen::REST::ModifyPayment::Response,
           response_options: {
-            prefix: 'modification_result',
             expects: '[capture-received]'
           }
         )
@@ -50,10 +48,8 @@ module Adyen
 
       def cancel_payment_request(attributes = {})
         Adyen::REST::ModifyPayment::Request.new('Payment.cancel', attributes,
-          prefix: 'modification_request',
           response_class: Adyen::REST::ModifyPayment::Response,
           response_options: {
-            prefix: 'modification_result',
             expects: '[cancel-received]'
           }
         )
@@ -67,10 +63,8 @@ module Adyen
 
       def refund_payment_request(attributes = {})
         Adyen::REST::ModifyPayment::Request.new('Payment.refund', attributes,
-          prefix: 'modification_request',
           response_class: Adyen::REST::ModifyPayment::Response,
           response_options: {
-            prefix: 'modification_result',
             expects: '[refund-received]'
           }
         )
@@ -84,10 +78,8 @@ module Adyen
 
       def cancel_or_refund_payment_request(attributes = {})
         Adyen::REST::ModifyPayment::Request.new('Payment.cancelOrRefund', attributes,
-          prefix: 'modification_request',
           response_class: Adyen::REST::ModifyPayment::Response,
           response_options: {
-            prefix: 'modification_result',
             expects: '[cancelOrRefund-received]'
           }
         )

--- a/lib/adyen/rest/parse_adyen_response.rb
+++ b/lib/adyen/rest/parse_adyen_response.rb
@@ -1,0 +1,58 @@
+require 'adyen/util'
+
+module Adyen
+  module REST
+    module ParseReponse
+      attr_reader :http_response, :prefix, :attributes
+
+      # Looks up an attribute in the response.
+      # @return [String, nil] The value of the attribute if it was included in the response.
+      def [](name)
+        attributes[canonical_name(name)]
+      end
+
+      def has_attribute?(name)
+        attributes.has_key?(canonical_name(name))
+      end
+
+      def psp_reference
+        Integer(self[:psp_reference])
+      end
+
+      protected
+
+      def map_response_list(response_prefix, mapped_attributes)
+        list  = []
+        index = 0
+
+        loop do
+          response = {}
+          mapped_attributes.each do |key, value|
+            new_value = attributes["#{response_prefix}.#{index.to_s}.#{value}"]
+            response[key] = new_value unless new_value.empty?
+          end
+
+          index += 1
+          break unless response.any?
+          list << response
+        end
+
+        list
+      end
+
+      def canonical_name(name)
+        Adyen::Util.camelize(apply_prefix(name))
+      end
+
+      def apply_prefix(name)
+        prefix ? name.to_s.sub(/\A(?!#{Regexp.quote(prefix)}\.)/, "#{prefix}.") : name.to_s
+      end
+
+      def parse_response_attributes
+        attributes = CGI.parse(http_response.body)
+        attributes.each { |key, values| attributes[key] = values.first }
+        attributes
+      end
+    end
+  end
+end

--- a/lib/adyen/rest/payout.rb
+++ b/lib/adyen/rest/payout.rb
@@ -1,0 +1,89 @@
+module Adyen
+  module REST
+    # This module implements the <b>Payout</b>
+    # API calls, and includes a custom response class to make handling the response easier.
+    # https://docs.adyen.com/developers/payout-manual
+    module Payout
+      class Request < Adyen::REST::Request
+      end
+
+      class Response < Adyen::REST::Response
+
+        def success?
+          result_code == SUCCESS
+        end
+
+        def received?
+          result_code == RECEIVED
+        end
+
+        def confirmed?
+          response == CONFIRMED
+        end
+
+        def declined?
+          response == DECLINED
+        end
+
+        def result_code
+          self[:result_code]
+        end
+
+        def psp_reference
+          self[:psp_reference]
+        end
+
+        def response
+          self[:response]
+        end
+
+        SUCCESS          = 'Success'.freeze
+        RECEIVED         = '[payout-submit-received]'.freeze
+        CONFIRMED        = '[payout-confirm-received]'.freeze
+        DECLINED         = '[payout-decline-received]'.freeze
+        private_constant :SUCCESS, :RECEIVED, :CONFIRMED, :DECLINED
+      end
+
+      # Constructs and issues a Payment.capture API call.
+      def store_payout(attributes = {})
+        request = store_request('Payout.storeDetail', attributes)
+        execute_request(request)
+      end
+
+      def submit_payout(attributes = {})
+        request = store_request('Payout.submit', attributes)
+        execute_request(request)
+      end
+
+      def submit_and_store_payout(attributes = {})
+        request = store_request('Payout.storeDetailAndSubmit', attributes)
+        execute_request(request)
+      end
+
+      def confirm_payout(attributes = {})
+        request = review_request('Payout.confirm', attributes)
+        execute_request(request)
+      end
+
+      def decline_payout(attributes = {})
+        request = review_request('Payout.decline', attributes)
+        execute_request(request)
+      end
+
+      private
+      # Require you to use a client initialize with payout_store
+      def store_request(action, attributes)
+        Adyen::REST::Payout::Request.new(action, attributes,
+          response_class: Adyen::REST::Payout::Response
+        )
+      end
+
+      # Require you to use a client initialize with payout review
+      def review_request(action, attributes)
+        Adyen::REST::Payout::Request.new(action, attributes,
+          response_class: Adyen::REST::Payout::Response
+        )
+      end
+    end
+  end
+end

--- a/lib/adyen/rest/request.rb
+++ b/lib/adyen/rest/request.rb
@@ -33,8 +33,6 @@ module Adyen
       attr_accessor :response_class, :response_options
 
       def initialize(action, attributes, options = {})
-        raise Adyen::REST::RequiredParameterMissing, "actions is required!" if action.nil?
-
         @form_data = generate_form_data(attributes)
         @path = generate_path(action)
 

--- a/lib/adyen/rest/request.rb
+++ b/lib/adyen/rest/request.rb
@@ -60,7 +60,7 @@ module Adyen
       end
 
       def merchant_account=(value)
-        self[:merchant_account] = value
+        self[:merchantAccount] = value
       end
 
       # Runs validations on the request before it is sent.

--- a/lib/adyen/rest/request.rb
+++ b/lib/adyen/rest/request.rb
@@ -97,7 +97,7 @@ module Adyen
       end
 
       # @see Adyen::REST::Request#set_path
-      PATH = '/pal/servlet/%s/v12/%s'
+      PATH = '/pal/servlet/%s/v18/%s'
       private_constant :PATH
     end
   end

--- a/lib/adyen/rest/request.rb
+++ b/lib/adyen/rest/request.rb
@@ -29,17 +29,19 @@ module Adyen
     # @see Adyen::REST::Client
     # @see Adyen::REST::Response
     class Request
-      attr_reader :prefix, :form_data, :required_attributes
+      attr_reader :prefix, :form_data, :required_attributes, :resource
       attr_accessor :response_class, :response_options
 
       def initialize(action, attributes, options = {})
-        @prefix = options[:prefix]
-        @form_data = generate_form_data(action, attributes)
+        raise Adyen::REST::RequiredParameterMissing, "actions is required!" if action.nil?
+
+        @form_data = generate_form_data(attributes)
+        @resource = generate_resource(action)
 
         @response_class   = options[:response_class]   || Adyen::REST::Response
         @response_options = options[:response_options] || {}
 
-        @required_attributes = ['action']
+        @required_attributes = []
       end
 
       # Returns the request's action
@@ -105,6 +107,9 @@ module Adyen
 
       def generate_form_data(action, attributes)
         flatten_attributes(attributes).merge('action' => action.to_s)
+      end
+      def generate_resource(action)
+        '%s/v12/%s' % action.split('.')
       end
     end
   end

--- a/lib/adyen/rest/request.rb
+++ b/lib/adyen/rest/request.rb
@@ -29,14 +29,14 @@ module Adyen
     # @see Adyen::REST::Client
     # @see Adyen::REST::Response
     class Request
-      attr_reader :prefix, :form_data, :required_attributes, :resource
+      attr_reader :prefix, :form_data, :required_attributes, :path
       attr_accessor :response_class, :response_options
 
       def initialize(action, attributes, options = {})
         raise Adyen::REST::RequiredParameterMissing, "actions is required!" if action.nil?
 
         @form_data = generate_form_data(attributes)
-        @resource = generate_resource(action)
+        @path = generate_path(action)
 
         @response_class   = options[:response_class]   || Adyen::REST::Response
         @response_options = options[:response_options] || {}
@@ -94,9 +94,13 @@ module Adyen
         Adyen::Util.flatten(attributes)
       end
 
-      def generate_resource(action)
-        '%s/v12/%s' % action.split('.')
+      def generate_path(action)
+        PATH % action.split('.')
       end
+
+      # @see Adyen::REST::Request#set_path
+      PATH = '/pal/servlet/%s/v12/%s'
+      private_constant :PATH
     end
   end
 end

--- a/lib/adyen/rest/request.rb
+++ b/lib/adyen/rest/request.rb
@@ -57,7 +57,7 @@ module Adyen
 
       # Sets an attribute on the request
       def []=(attribute, value)
-        form_data.merge!(flatten_attributes(attribute => value))
+        form_data.merge!(Adyen::Util.flatten(attribute => value))
         value
       end
 
@@ -86,28 +86,14 @@ module Adyen
       protected
 
       def canonical_name(name)
-        Adyen::Util.camelize(apply_prefix(name))
+        Adyen::Util.camelize(name)
       end
 
-      def apply_prefix(name)
-        prefix ? name.to_s.sub(/\A(?!#{Regexp.quote(prefix)}\.)/, "#{prefix}.") : name.to_s
-      end
-
-      # Flattens the {#attributes} hash and converts all the keys to camelcase.
-      # @return [Hash] A potentially nested hash of attributes.
       # @return [Hash<String, String>] A dictionary of API request attributes that
-      #   can be included in an HTTP request as form data.
-      def flatten_attributes(attributes)
-        if prefix
-          Adyen::Util.flatten(prefix => attributes)
-        else
-          Adyen::Util.flatten(attributes)
-        end
+      def generate_form_data(attributes)
+        Adyen::Util.flatten(attributes)
       end
 
-      def generate_form_data(action, attributes)
-        flatten_attributes(attributes).merge('action' => action.to_s)
-      end
       def generate_resource(action)
         '%s/v12/%s' % action.split('.')
       end

--- a/lib/adyen/rest/response.rb
+++ b/lib/adyen/rest/response.rb
@@ -1,4 +1,5 @@
-require 'adyen/util'
+require 'adyen/rest/parse_adyen_response'
+
 
 module Adyen
   module REST
@@ -19,61 +20,12 @@ module Adyen
     # @see Adyen::REST::Client
     # @see Adyen::REST::Request
     class Response
-      attr_reader :http_response, :prefix, :attributes
+      include Adyen::REST::ParseReponse
 
       def initialize(http_response, options = {})
         @http_response = http_response
         @prefix = options.key?(:prefix) ? options[:prefix].to_s : nil
         @attributes = parse_response_attributes
-      end
-
-      # Looks up an attribute in the response.
-      # @return [String, nil] The value of the attribute if it was included in the response.
-      def [](name)
-        attributes[canonical_name(name)]
-      end
-
-      def has_attribute?(name)
-        attributes.has_key?(canonical_name(name))
-      end
-
-      def psp_reference
-        Integer(self[:psp_reference])
-      end
-
-      protected
-
-      def map_response_list(response_prefix, mapped_attributes)
-        list  = []
-        index = 0
-
-        loop do
-          response = {}
-          mapped_attributes.each do |key, value|
-            new_value = attributes["#{response_prefix}.#{index.to_s}.#{value}"]
-            response[key] = new_value unless new_value.empty?
-          end
-
-          index += 1
-          break unless response.any?
-          list << response
-        end
-
-        list
-      end
-
-      def canonical_name(name)
-        Adyen::Util.camelize(apply_prefix(name))
-      end
-
-      def apply_prefix(name)
-        prefix ? name.to_s.sub(/\A(?!#{Regexp.quote(prefix)}\.)/, "#{prefix}.") : name.to_s
-      end
-
-      def parse_response_attributes
-        attributes = CGI.parse(http_response.body)
-        attributes.each { |key, values| attributes[key] = values.first }
-        attributes
       end
     end
   end

--- a/test/functional/payment_authorisation_api_test.rb
+++ b/test/functional/payment_authorisation_api_test.rb
@@ -12,6 +12,7 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_payment_api_request
     response = @client.authorise_payment(
+      merchantAccount: 'VanBergenORG',
       amount: { currency: 'EUR', value: 1234 },
       reference: 'Test order #1',
       card: Adyen::TestCards::VISA
@@ -23,6 +24,7 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_refused_payment_api_request
     response = @client.authorise_payment(
+      merchantAccount: 'VanBergenORG',
       amount: { currency: 'EUR', value: 1234 },
       reference: 'Test order #1',
       card: Adyen::TestCards::VISA.merge(cvc: '123')
@@ -35,6 +37,7 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_payment_with_3d_secure_api_request
     response = @client.authorise_payment(
+      merchantAccount: 'VanBergenORG',
       amount: { currency: 'EUR', value: 1234 },
       reference: 'Test order #1',
       card: Adyen::TestCards::MASTERCARD_3DSECURE,
@@ -52,6 +55,7 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_initial_recurring_payment_api_request
     response = @client.authorise_recurring_payment(
+      merchantAccount: 'VanBergenORG',
       shopper_email: 'willem@van-bergen.org',
       shopper_reference: 'willem42',
       amount: { currency: 'EUR', value: 1234 },
@@ -65,6 +69,7 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_recurring_payment_api_request
     response = @client.reauthorise_recurring_payment(
+      merchantAccount: 'VanBergenORG',
       shopper_email: 'willem@van-bergen.org',
       shopper_reference: 'willem42',
       amount: { currency: 'EUR', value: 1234 },
@@ -77,6 +82,7 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_list_recurring_details_api_request
     response = @client.list_recurring_details(
+      merchantAccount: 'VanBergenORG',
       recurring: { contract: "RECURRING" },
       shopper_reference: 'willem42',
     )
@@ -91,6 +97,7 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_list_recurring_references_api_request
     response = @client.list_recurring_details(
+      merchantAccount: 'VanBergenORG',
       recurring: { contract: "RECURRING" },
       shopper_reference: 'willem42',
     )

--- a/test/functional/payment_authorisation_api_test.rb
+++ b/test/functional/payment_authorisation_api_test.rb
@@ -12,7 +12,6 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_payment_api_request
     response = @client.authorise_payment(
-      merchant_account: 'VanBergenORG',
       amount: { currency: 'EUR', value: 1234 },
       reference: 'Test order #1',
       card: Adyen::TestCards::VISA
@@ -24,7 +23,6 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_refused_payment_api_request
     response = @client.authorise_payment(
-      merchant_account: 'VanBergenORG',
       amount: { currency: 'EUR', value: 1234 },
       reference: 'Test order #1',
       card: Adyen::TestCards::VISA.merge(cvc: '123')
@@ -37,7 +35,6 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_payment_with_3d_secure_api_request
     response = @client.authorise_payment(
-      merchant_account: 'VanBergenORG',
       amount: { currency: 'EUR', value: 1234 },
       reference: 'Test order #1',
       card: Adyen::TestCards::MASTERCARD_3DSECURE,
@@ -55,7 +52,6 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_initial_recurring_payment_api_request
     response = @client.authorise_recurring_payment(
-      merchant_account: 'VanBergenORG',
       shopper_email: 'willem@van-bergen.org',
       shopper_reference: 'willem42',
       amount: { currency: 'EUR', value: 1234 },
@@ -69,7 +65,6 @@ class PaymentAuthorisationAPITest < Minitest::Test
 
   def test_recurring_payment_api_request
     response = @client.reauthorise_recurring_payment(
-      merchant_account: 'VanBergenORG',
       shopper_email: 'willem@van-bergen.org',
       shopper_reference: 'willem42',
       amount: { currency: 'EUR', value: 1234 },
@@ -83,7 +78,6 @@ class PaymentAuthorisationAPITest < Minitest::Test
   def test_list_recurring_details_api_request
     response = @client.list_recurring_details(
       recurring: { contract: "RECURRING" },
-      merchant_account: 'VanBergenORG',
       shopper_reference: 'willem42',
     )
 
@@ -98,7 +92,6 @@ class PaymentAuthorisationAPITest < Minitest::Test
   def test_list_recurring_references_api_request
     response = @client.list_recurring_details(
       recurring: { contract: "RECURRING" },
-      merchant_account: 'VanBergenORG',
       shopper_reference: 'willem42',
     )
 

--- a/test/functional/payment_modification_api_test.rb
+++ b/test/functional/payment_modification_api_test.rb
@@ -12,7 +12,7 @@ class PaymentModificationAPITest < Minitest::Test
 
   def test_capture_payment_api_request
     response = @client.capture_payment(
-      merchant_account: 'VanBergenORG',
+      merchantAccount: 'VanBergenORG',
       modification_amount: { currency: 'EUR', value: 1234 },
       reference: "functional test for cancellation",
       original_reference: 7913939284323855
@@ -24,7 +24,7 @@ class PaymentModificationAPITest < Minitest::Test
 
   def test_cancel_payment_api_request
     response = @client.cancel_payment(
-      merchant_account: 'VanBergenORG',
+      merchantAccount: 'VanBergenORG',
       reference: "functional test for cancellation",
       original_reference: 7913939284323855
     )
@@ -35,7 +35,7 @@ class PaymentModificationAPITest < Minitest::Test
 
   def test_refund_payment_api_request
     response = @client.refund_payment(
-      merchant_account: 'VanBergenORG',
+      merchantAccount: 'VanBergenORG',
       modification_amount: { currency: 'EUR', value: 1234 },
       reference: "functional test for cancellation",
       original_reference: 7913939284323855
@@ -47,7 +47,7 @@ class PaymentModificationAPITest < Minitest::Test
 
   def test_cancel_or_refund_payment_api_request
     response = @client.cancel_or_refund_payment(
-      merchant_account: 'VanBergenORG',
+      merchantAccount: 'VanBergenORG',
       reference: "functional test for cancellation",
       original_reference: 7913939284323855
     )

--- a/test/functional/payout_api_test.rb
+++ b/test/functional/payout_api_test.rb
@@ -1,0 +1,90 @@
+require 'test_helper'
+require 'adyen/rest'
+
+class PayoutAPITest < Minitest::Test
+  def setup
+    @client =  Adyen::REST::Client.new(
+      :test,
+      Adyen.configuration.payout_store_username,
+      Adyen.configuration.payout_store_password,
+      Adyen.configuration.default_api_params
+    )
+  end
+
+  def teardown
+    @client.close
+  end
+
+  def test_submit_and_store_request
+    response = @client.submit_and_store_payout(
+      amount: { currency: 'EUR', value: 20},
+      bank: { iban: 'NL48RABO0132394782', bankName: 'Rabobank', countryCode: 'NL', ownerName: 'Test shopper' },
+      recurring: { contract: 'PAYOUT' },
+      reference: 'PayoutPayment-0001',
+      shopperEmail: 'shopper@example.com',
+      shopperReference: 'ShopperFoo'
+    )
+
+    assert response.received?
+    assert response.psp_reference
+  end
+
+  def test_store_request
+    response = @client.store_payout(
+      bank: { iban: 'NL48RABO0132394782', bankName: 'Rabobank', countryCode: 'NL', ownerName: 'Test shopper' },
+      recurring: { contract: 'PAYOUT' },
+      shopperEmail: 'shopper@example.com',
+      shopperReference: 'ShopperFoo'
+    )
+
+    assert response.success?
+    assert response.psp_reference
+  end
+
+  def test_submit_request
+    response = @client.submit_payout(
+      amount: { currency: 'EUR', value: 20 },
+      recurring: { contract: 'PAYOUT' },
+      reference: 'PayoutPayment-0001',
+      shopperEmail: 'shopper@example.com',
+      shopperReference: 'ShopperFoo',
+      selectedRecurringDetailReference: 'LATEST'
+    )
+
+    assert response.received?
+    assert response.psp_reference
+  end
+end
+
+class PayoutReviewTest < Minitest::Test
+  def setup
+    @client =  Adyen::REST::Client.new(
+      :test,
+      Adyen.configuration.payout_review_username,
+      Adyen.configuration.payout_review_password,
+      Adyen.configuration.default_api_params
+    )
+  end
+
+  def teardown
+    @client.close
+  end
+
+  def test_confirm_payout
+    response = @client.confirm_payout(
+      originalReference: '1234'
+    )
+
+    assert response.confirmed?
+    assert response.psp_reference
+  end
+
+  def test_decline_payout
+    response = @client.decline_payout(
+      originalReference: '1234'
+    )
+
+    assert response.declined?
+    assert response.psp_reference
+  end
+end

--- a/test/functional/payout_api_test.rb
+++ b/test/functional/payout_api_test.rb
@@ -5,9 +5,8 @@ class PayoutAPITest < Minitest::Test
   def setup
     @client =  Adyen::REST::Client.new(
       :test,
-      Adyen.configuration.payout_store_username,
-      Adyen.configuration.payout_store_password,
-      Adyen.configuration.default_api_params
+      'storePayout@Company.VanBergen',
+      'xxWWcc'
     )
   end
 
@@ -17,6 +16,7 @@ class PayoutAPITest < Minitest::Test
 
   def test_submit_and_store_request
     response = @client.submit_and_store_payout(
+      merchantAccount: 'VanBergenORG',
       amount: { currency: 'EUR', value: 20},
       bank: { iban: 'NL48RABO0132394782', bankName: 'Rabobank', countryCode: 'NL', ownerName: 'Test shopper' },
       recurring: { contract: 'PAYOUT' },
@@ -31,6 +31,7 @@ class PayoutAPITest < Minitest::Test
 
   def test_store_request
     response = @client.store_payout(
+      merchantAccount: 'VanBergenORG',
       bank: { iban: 'NL48RABO0132394782', bankName: 'Rabobank', countryCode: 'NL', ownerName: 'Test shopper' },
       recurring: { contract: 'PAYOUT' },
       shopperEmail: 'shopper@example.com',
@@ -43,6 +44,7 @@ class PayoutAPITest < Minitest::Test
 
   def test_submit_request
     response = @client.submit_payout(
+      merchantAccount: 'VanBergenORG',
       amount: { currency: 'EUR', value: 20 },
       recurring: { contract: 'PAYOUT' },
       reference: 'PayoutPayment-0001',
@@ -60,9 +62,8 @@ class PayoutReviewTest < Minitest::Test
   def setup
     @client =  Adyen::REST::Client.new(
       :test,
-      Adyen.configuration.payout_review_username,
-      Adyen.configuration.payout_review_password,
-      Adyen.configuration.default_api_params
+      'reviewPayout@Company.VanBergen',
+      'ssWWcc'
     )
   end
 
@@ -72,6 +73,7 @@ class PayoutReviewTest < Minitest::Test
 
   def test_confirm_payout
     response = @client.confirm_payout(
+      merchantAccount: 'VanBergenORG',
       originalReference: '1234'
     )
 
@@ -81,6 +83,7 @@ class PayoutReviewTest < Minitest::Test
 
   def test_decline_payout
     response = @client.decline_payout(
+      merchantAccount: 'VanBergenORG',
       originalReference: '1234'
     )
 

--- a/test/helpers/configure_adyen.rb
+++ b/test/helpers/configure_adyen.rb
@@ -1,10 +1,6 @@
 Adyen.configuration.default_api_params = { :merchant_account => 'VanBergenORG' }
 Adyen.configuration.api_username = 'ws@Company.VanBergen'
 Adyen.configuration.api_password = '7phtHzbfnzsp'
-Adyen.configuration.payout_store_username = 'storePayout@Company.VanBergen'
-Adyen.configuration.payout_store_password = '1234'
-Adyen.configuration.payout_review_username = 'reviewPayout@Company.VanBergen'
-Adyen.configuration.payout_review_password = '1234'
 Adyen.configuration.cse_public_key = '10001|AC2CEF7D1BE904AF35B76467927A7044CCFC470E725B4D5327CC143BC5245983A56A4E5B0AC969F7F706F4B4A81B184DE2ECEA229CDBB943E6F7D6AD1623604F66640D1F2FAE1E4AE80EE1E5D4486AA8F553F6CE47BF57C8EFEF745E731AE27DD7B74F8895D41DA8339CC32677E4BD35288EC2FB9A18D46E7E3DFF5C7DD6D756F2223BED29427E5899A5877F0E9D1FAA50C17F8C96BA96DFA79BD04B1116366FFEE33F1BD18B8C3694BACBF8BFC7E2045CB9FFFEFA49AAB18EF1D9E9710A16B7DC67433ABD3A4FD3661CD9F5B1967753E4DC744DD3A1F8C8BED87827EED443CBED06A0D5C86C329406BE452B9A6EB997EE43A9FA7241A74E87AC3FC898F327CD'
 Adyen.configuration.register_form_skin(:testing, 'tifSfXeX', 'testing123', :merchant_account => 'VanBergenORG')
 Adyen.configuration.default_skin = :testing

--- a/test/helpers/configure_adyen.rb
+++ b/test/helpers/configure_adyen.rb
@@ -1,6 +1,10 @@
 Adyen.configuration.default_api_params = { :merchant_account => 'VanBergenORG' }
 Adyen.configuration.api_username = 'ws@Company.VanBergen'
 Adyen.configuration.api_password = '7phtHzbfnzsp'
+Adyen.configuration.payout_store_username = 'storePayout@Company.VanBergen'
+Adyen.configuration.payout_store_password = '1234'
+Adyen.configuration.payout_review_username = 'reviewPayout@Company.VanBergen'
+Adyen.configuration.payout_review_password = '1234'
 Adyen.configuration.cse_public_key = '10001|AC2CEF7D1BE904AF35B76467927A7044CCFC470E725B4D5327CC143BC5245983A56A4E5B0AC969F7F706F4B4A81B184DE2ECEA229CDBB943E6F7D6AD1623604F66640D1F2FAE1E4AE80EE1E5D4486AA8F553F6CE47BF57C8EFEF745E731AE27DD7B74F8895D41DA8339CC32677E4BD35288EC2FB9A18D46E7E3DFF5C7DD6D756F2223BED29427E5899A5877F0E9D1FAA50C17F8C96BA96DFA79BD04B1116366FFEE33F1BD18B8C3694BACBF8BFC7E2045CB9FFFEFA49AAB18EF1D9E9710A16B7DC67433ABD3A4FD3661CD9F5B1967753E4DC744DD3A1F8C8BED87827EED443CBED06A0D5C86C329406BE452B9A6EB997EE43A9FA7241A74E87AC3FC898F327CD'
 Adyen.configuration.register_form_skin(:testing, 'tifSfXeX', 'testing123', :merchant_account => 'VanBergenORG')
 Adyen.configuration.default_skin = :testing

--- a/test/unit/rest/client_test.rb
+++ b/test/unit/rest/client_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+require 'adyen/rest/client'
+
+class RESTClientTest < Minitest::Test
+  def test_endpoint_dev
+    client =  Adyen::REST::Client.new(
+        :test,
+        'login',
+        'password'
+    )
+
+    assert_equal client.http.address, 'pal-test.adyen.com'
+  end
+
+  def test_endpoint_live
+    client =  Adyen::REST::Client.new(
+        :live,
+        'login',
+        'password'
+    )
+
+    assert_equal client.http.address, 'pal-live.adyen.com'
+  end
+
+  def test_endpoint_live_with_merchant
+    merchant = 'merchantEndpoint'
+
+    client =  Adyen::REST::Client.new(
+        :live,
+        'login',
+        'password',
+        merchant
+    )
+
+    assert_equal client.http.address, "#{merchant}.pal-live.adyenpayments.com"
+  end
+end

--- a/test/unit/rest_list_recurring_details_response_test.rb
+++ b/test/unit/rest_list_recurring_details_response_test.rb
@@ -5,11 +5,11 @@ class ListRecurringDetailsResponse < Minitest::Test
 
   def setup
     @http_response = mock
-    @recurring_detail_reference = "8314231570619177" 
-    @body = "recurringDetailsResult.shopperReference=lup%40lup.com%23555&recurringDetailsResult.details.0.variant=mc&recurringDetailsResult.details.0.card.number=1111&recurringDetailsResult.details.0.recurringDetailReference=#{@recurring_detail_reference}&recurringDetailsResult.details.0.card.expiryMonth=6&recurringDetailsResult.creationDate=2015-02-05T18%3A24%3A21%2B01%3A00&recurringDetailsResult.lastKnownShopperEmail=lup%40lup.com&recurringDetailsResult.details.0.creationDate=2015-02-05T18%3A24%3A21%2B01%3A00&recurringDetailsResult.details.0.card.expiryYear=2016&recurringDetailsResult.details.0.card.holderName=jose"
+    @recurring_detail_reference = "8314231570619177"
+    @body = "shopperReference=lup%40lup.com%23555&details.0.variant=mc&details.0.card.number=1111&details.0.recurringDetailReference=#{@recurring_detail_reference}&details.0.card.expiryMonth=6&creationDate=2015-02-05T18%3A24%3A21%2B01%3A00&lastKnownShopperEmail=lup%40lup.com&details.0.creationDate=2015-02-05T18%3A24%3A21%2B01%3A00&details.0.card.expiryYear=2016&details.0.card.holderName=jose"
     @expected_details = [{ recurring_detail_reference: @recurring_detail_reference, creation_date: "2015-02-05T18:24:21+01:00", variant: "mc", card_holder_name: "jose", card_expiry_month: "6", card_expiry_year: "2016", card_number: "1111" }]
     @http_response.stubs(body: @body)
-    @response = Adyen::REST::AuthorisePayment::ListRecurringDetailsResponse.new(@http_response, prefix: 'recurring_details_result')
+    @response = Adyen::REST::AuthorisePayment::ListRecurringDetailsResponse.new(@http_response)
   end
 
   def test_getting_details

--- a/test/unit/rest_request_test.rb
+++ b/test/unit/rest_request_test.rb
@@ -14,38 +14,34 @@ class RESTRequestTest < Minitest::Test
   end
 
   def test_form_data
-    request = Adyen::REST::Request.new('Test', @attributes, prefix: 'prefix')
-    assert_equal 'Test', request.action
+    request = Adyen::REST::Request.new('Action.Test', @attributes)
 
     form_data = request.form_data
-    assert_equal 'Test', form_data['action']
-    assert_equal '123',  form_data['prefix.test']
-    assert_equal '456',  form_data['prefix.nested.camelCase']
+    assert_equal '123',  form_data['test']
+    assert_equal '456',  form_data['nested.camelCase']
   end
 
   def test_action_is_required
-    request = Adyen::REST::Request.new(nil, @attributes)
-    assert_raises(Adyen::REST::RequestValidationFailed) { request.validate! }
+    assert_raises(Adyen::REST::RequiredParameterMissing) { Adyen::REST::Request.new(nil, @attributes) }
   end
 
   def test_setting_attributes
-    request = Adyen::REST::Request.new('Test', @attributes, prefix: 'prefix')
+    request = Adyen::REST::Request.new('Action.Test', @attributes)
     request[:nested] = { a: 1, b: 2 }
     request[:c] = 'hello world'
     request[:camel_case] = 'snake_case'
 
-    assert_equal '1', request.form_data['prefix.nested.a']
-    assert_equal '2', request.form_data['prefix.nested.b']
-    assert_equal 'hello world', request.form_data['prefix.c']
-    assert_equal 'snake_case', request.form_data['prefix.camelCase']
+    assert_equal '1', request.form_data['nested.a']
+    assert_equal '2', request.form_data['nested.b']
+    assert_equal 'hello world', request.form_data['c']
+    assert_equal 'snake_case', request.form_data['camelCase']
   end
 
   def test_getting_attributes
-    request = Adyen::REST::Request.new('Test', @attributes, prefix: 'prefix')
+    request = Adyen::REST::Request.new('Action.Test', @attributes)
     assert_equal '123', request['test']
     assert_equal '123', request[:test]
     assert_equal '456', request['nested.camel_case']
-    assert_equal '456', request['prefix.nested.camel_case']
-    assert_equal '456', request['prefix.nested.camelCase']
+    assert_equal '456', request['nested.camelCase']
   end
 end

--- a/test/unit/rest_request_test.rb
+++ b/test/unit/rest_request_test.rb
@@ -21,10 +21,6 @@ class RESTRequestTest < Minitest::Test
     assert_equal '456',  form_data['nested.camelCase']
   end
 
-  def test_action_is_required
-    assert_raises(Adyen::REST::RequiredParameterMissing) { Adyen::REST::Request.new(nil, @attributes) }
-  end
-
   def test_setting_attributes
     request = Adyen::REST::Request.new('Action.Test', @attributes)
     request[:nested] = { a: 1, b: 2 }


### PR DESCRIPTION
Implementation of https://docs.adyen.com/developers/payout-manual

I also have replaced the old 'universal' endpoint (`/httppost`) by theirs real REST endpoint, which remove the need of prefixes.

Btw, currently the tests will fail if you don't have a storePayout & a reviewPayout user. Which seems wrong to me, what do you think?

Alex
