### PR TITLE
Fix test suite

### DIFF
--- a/adyen.gemspec
+++ b/adyen.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('sinatra')
   s.add_development_dependency('poltergeist')
 
-  s.add_development_dependency('rails', '>= 3.2')
-  s.add_development_dependency('nokogiri', '>= 1.6.1')
+  s.add_development_dependency('railties', '>= 3.2', '< 5')
+  s.add_development_dependency('nokogiri', '>= 1.6.8')
 
   s.requirements << 'Having Nokogiri installed will speed up XML handling when using the SOAP API.'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ require 'helpers/configure_adyen'
 require 'helpers/test_cards'
 
 require 'pp'
+require 'time'
 
 module Adyen::Test
   module Flaky


### PR DESCRIPTION
The test suite was not running locally for me.

- Add `require 'time'` to make sure `Time.parse` is available
- Update rails development dependency; Rails 5 only works with Ruby 2.2.2, but this library supports Ruby 2.0 and up.