### PR TITLE
extend mandatory attributes in HPP-Request

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This projects welcomes outside contributions from anyone.
 
 Please report bugs as a [Github issue](https://github.com/wvanbergen/adyen/issues/new).
 
-- We are not associated with Adyen. Please contact Adyen youself if you are having
+- We are not associated with Adyen. Please contact Adyen yourself if you are having
   trouble with your integration.
 - This library supports several features that are not supported by default on a new
   Adyen account. You may have to contact Adyen if you are receiving a

--- a/lib/adyen/hpp/request.rb
+++ b/lib/adyen/hpp/request.rb
@@ -9,6 +9,8 @@ module Adyen
       attr_accessor :parameters
       attr_writer :skin, :environment, :shared_secret
 
+      MANDATORY_ATTRIBUTES = %i(currency_code payment_amount merchant_account skin_code ship_before_date session_validity).freeze
+
       # Initialize the HPP request
       #
       # @param [Hash] parameters The payment parameters
@@ -88,10 +90,9 @@ module Adyen
         end
         formatted_parameters = default_form_parameters.merge(formatted_parameters)
 
-        raise ArgumentError, "Cannot generate request: :currency code attribute not found!"         unless formatted_parameters[:currency_code]
-        raise ArgumentError, "Cannot generate request: :payment_amount code attribute not found!"   unless formatted_parameters[:payment_amount]
-        raise ArgumentError, "Cannot generate request: :merchant_account attribute not found!"      unless formatted_parameters[:merchant_account]
-        raise ArgumentError, "Cannot generate request: :skin_code attribute not found!"             unless formatted_parameters[:skin_code]
+        MANDATORY_ATTRIBUTES.each do |attribute|
+          raise ArgumentError, "Cannot generate request: :#{attribute} attribute not found!" unless formatted_parameters[attribute]
+        end
 
         formatted_parameters[:recurring_contract] = 'RECURRING' if formatted_parameters.delete(:recurring) == true
         formatted_parameters[:order_data]         = Adyen::Util.gzip_base64(formatted_parameters.delete(:order_data_raw)) if formatted_parameters[:order_data_raw]

--- a/test/unit/hpp/request_test.rb
+++ b/test/unit/hpp/request_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+require 'adyen/hpp/request'
+
+class HPPRequestTest < Minitest::Test
+  def setup
+    Adyen.configuration.default_form_params[:merchant_account] = 'TestMerchant'
+    Adyen.configuration.default_skin = :skin1
+
+    # Use autodetection for the environment unless otherwise specified
+    Adyen.configuration.environment = nil
+    Adyen.configuration.payment_flow = :select
+    Adyen.configuration.payment_flow_domain = nil
+    Adyen.configuration.default_skin = :skin1
+
+    @raw_params = {
+      :merchant_account => 'TestMerchant',
+      :currency_code => 'EUR',
+      :payment_amount => '199',
+      :session_validity => '2015-06-25T10:31:06Z',
+      :ship_before_date => '2015-07-01',
+      :shopper_locale => 'en_GB',
+      :merchant_reference => 'SKINTEST-1435226439255',
+      :skin_code => 'X7hsNDWp',
+    }
+  end
+
+  def test_formatted_parameters
+    expected_parameters = {
+      merchant_account: "TestMerchant",
+      currency_code: "EUR",
+      payment_amount: "199",
+      session_validity: "2015-06-25T10:31:06Z",
+      ship_before_date: "2015-07-01",
+      shopper_locale: "en_GB",
+      merchant_reference: "SKINTEST-1435226439255",
+      skin_code: "X7hsNDWp"}
+
+    parameters = Adyen::HPP::Request.new(@raw_params).formatted_parameters
+    assert_equal parameters, expected_parameters
+  end
+
+  def test_formatted_parameters_without_parameters
+    request = Adyen::HPP::Request.new('String')
+
+    exception = assert_raises(ArgumentError) { request.formatted_parameters }
+    assert_equal("Cannot generate request: parameters should be a hash!", exception.message)
+  end
+
+  def test_formatted_parameters_without_currency_code
+    @raw_params.delete(:currency_code)
+    request = Adyen::HPP::Request.new(@raw_params)
+
+    exception = assert_raises(ArgumentError) { request.formatted_parameters }
+    assert_equal("Cannot generate request: :currency_code attribute not found!", exception.message)
+  end
+
+  def test_formatted_parameters_missing_parameters
+    Adyen.configuration.default_form_params[:merchant_account] = nil
+    Adyen.configuration.default_skin = 'unknown_skin'
+    %i(currency_code payment_amount merchant_account skin_code ship_before_date session_validity).each do |parameter|
+      params = @raw_params.reject { |param| param == parameter }
+      request = Adyen::HPP::Request.new(params)
+
+      exception = assert_raises(ArgumentError) { request.formatted_parameters }
+      assert_equal("Cannot generate request: :#{parameter} attribute not found!", exception.message)
+    end
+  end
+end


### PR DESCRIPTION
Hi,
Working with the HPP::Request, I ran into the issue, that the mandatory attributes aren't well communicated and according to the [adyen specs](https://docs.adyen.com/developers/hpp-manual#hpppaymentfields). So here, I extended the check for required attributes.
regards, Daniel
