### PR TITLE
Adding support for shopperStatements to Billet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The following changes have been made to the library over the years. Pleae add an
 
 #### Unrelease changes
 
-Nothing yet!
+- Add `shopper_statement` option to `Adyen::APP`, allowing to generate Billets with custom payment instructions.
 
 #### Version 2.2.0
 

--- a/lib/adyen/api.rb
+++ b/lib/adyen/api.rb
@@ -49,7 +49,7 @@ module Adyen
   module API
     extend self
 
-    # Generate a Billet - *Brazian users only*
+    # Generate a Billet - *Brazillian users only*
     #
     # Billet (Boleto Bancário), often simply referred to as Boleto, is an
     # offline payment method used in Brazil . The consumer will take the Boleto form to
@@ -66,17 +66,20 @@ module Adyen
     #     { currency: "BRL", value: (invoice.amount).to_i },
     #     { first_name: "Simon", last_name: "Hopper" },
     #     document_number,
-    #     selected_brand
+    #     selected_brand,
+    #     "2016-10-29T23:00:00.000Z",
+    #     "Please send payment email to payment@example.com after payment."
     #   )
     #   response.success? # => true
     #
     #
-    # @param          [Numeric,String] reference        Your reference (ID) for this payment.
-    # @param          [Hash]           amount           A hash describing the money to charge.
-    # @param          [Hash]           shopper          A hash describing the shopper.
-    # @param          [String]         document_number  Social Security
-    # number(CPF in Brazil)
-    # @param          [String]         selected_brand   Billet brand
+    # @param          [Numeric,String] reference          Your reference (ID) for this payment.
+    # @param          [Hash]           amount             A hash describing the money to charge.
+    # @param          [Hash]           shopper_name       A hash describing the shopper.
+    # @param          [String]         document_number    Social Security number (CPF in Brazil)
+    # @param          [String]         selected_brand     Billet brand
+    # @param          [String]         delivery_date      Payment date limit in ISO8601 format
+    # @param optional [String]         shopper_statement  Payment instructions to Shopper
     #
     # @option amount  [String]         :currency      The ISO currency code (EUR, GBP, USD, etc).
     # @option amount  [Integer]        :value         The value of the payment in discrete cents,
@@ -88,13 +91,14 @@ module Adyen
     #
     # @return [PaymentService::BilletResponse] The response object which holds the billet url.
     #
-    def generate_billet(reference, amount, shopper_name, social_security_number, selected_brand, delivery_date)
+    def generate_billet(reference, amount, shopper_name, social_security_number, selected_brand, delivery_date, shopper_statement = nil)
       params = { :reference              => reference,
                  :amount                 => amount,
                  :shopper_name           => shopper_name,
                  :social_security_number => social_security_number,
                  :selected_brand         => selected_brand,
-                 :delivery_date          => delivery_date }
+                 :delivery_date          => delivery_date,
+                 :shopper_statement      => shopper_statement }
       PaymentService.new(params).generate_billet
     end
 

--- a/lib/adyen/api/payment_service.rb
+++ b/lib/adyen/api/payment_service.rb
@@ -126,6 +126,7 @@ module Adyen
         content << shopper_name_partial if @params[:shopper_name]
         content << delivery_date_partial if @params[:delivery_date]
         content << selected_brand_partial if @params[:selected_brand]
+        content << shopper_statement_partial if @params[:shopper_statement]
         LAYOUT % [@params[:merchant_account], @params[:reference], content]
       end
 
@@ -208,6 +209,12 @@ module Adyen
 
       def shopper_partial
         @params[:shopper].map { |k, v| SHOPPER_PARTIALS[k] % v }.join("\n")
+      end
+
+      def shopper_statement_partial
+        if @params[:shopper_statement]
+          SHOPPER_STATEMENT % @params[:shopper_statement]
+        end
       end
 
       def fraud_offset_partial

--- a/lib/adyen/api/templates/payment_service.rb
+++ b/lib/adyen/api/templates/payment_service.rb
@@ -107,6 +107,11 @@ module Adyen
       EOXML
 
       # @private
+      SHOPPER_STATEMENT = <<-EOXML
+        <payment:shopperStatement>%s</payment:shopperStatement>
+      EOXML
+
+      # @private
       ENCRYPTED_CARD_PARTIAL = <<-EOXML
         <additionalAmount xmlns="http://payment.services.adyen.com" xsi:nil="true" />
         <additionalData xmlns="http://payment.services.adyen.com">

--- a/test/functional/api_test.rb
+++ b/test/functional/api_test.rb
@@ -111,7 +111,8 @@ if File.exist?(API_SPEC_INITIALIZER)
                                             { first_name: "Jow", last_name: "Silver" },
                                             "19762003691",
                                             "boletobancario_santander",
-                                            "2014-07-16T18:16:11Z")
+                                            "2014-07-16T18:16:11Z",
+                                            "free-text billet payment instructions")
       response.must_be :success?
     end
   end


### PR DESCRIPTION
Needed to provide [shopper statements](https://docs.adyen.com/developers/api-manual#boletobancario) to proper create Billets with payment instructions, so I added support for it.
