### PR TITLE
Remove non-ASCII characters from test descriptions

### DIFF
--- a/test/unit/api/payment_service_test.rb
+++ b/test/unit/api/payment_service_test.rb
@@ -18,7 +18,7 @@ module SharedExamples
       end
     end
 
-    it "includes the shopper’s details" do
+    it "includes the shopper's details" do
       text('./payment:shopperReference').must_equal 'user-id'
       text('./payment:shopperEmail').must_equal 's.hopper@example.com'
       text('./payment:shopperIP').must_equal '61.294.12.12'
@@ -171,7 +171,7 @@ describe Adyen::API::PaymentService do
       end
     end
 
-    it "formats the creditcard’s expiry month as a two digit number" do
+    it "formats the creditcard's expiry month as a two digit number" do
       @payment.params[:card][:expiry_month] = 6
       text('./payment:card/payment:expiryMonth').must_equal '06'
     end
@@ -328,7 +328,7 @@ describe Adyen::API::PaymentService do
       text('./payment:selectedRecurringDetailReference').must_equal 'LATEST'
     end
 
-    it "obviously includes the obligatory self-‘describing’ nonsense parameters" do
+    it "obviously includes the obligatory self-'describing' nonsense parameters" do
       text('./payment:shopperInteraction').must_equal 'ContAuth'
     end
 
@@ -362,7 +362,7 @@ describe Adyen::API::PaymentService do
       text('./payment:recurring/payment:contract').must_equal 'ONECLICK'
     end
 
-    it "does not include the self-‘describing’ nonsense parameters" do
+    it "does not include the self-'describing' nonsense parameters" do
       xpath('./payment:shopperInteraction').must_be :empty?
     end
 

--- a/test/unit/api/recurring_service_test.rb
+++ b/test/unit/api/recurring_service_test.rb
@@ -49,7 +49,7 @@ describe Adyen::API::RecurringService do
       text('./recurring:merchantAccount').must_equal 'SuperShopper'
     end
 
-    it "includes the shopper’s reference" do
+    it "includes the shopper's reference" do
       text('./recurring:shopperReference').must_equal 'user-id'
     end
 
@@ -126,7 +126,7 @@ describe Adyen::API::RecurringService do
       text('./recurring:merchantAccount').must_equal 'SuperShopper'
     end
 
-    it "includes the shopper’s reference" do
+    it "includes the shopper's reference" do
       text('./recurring:shopperReference').must_equal 'user-id'
     end
 
@@ -134,7 +134,7 @@ describe Adyen::API::RecurringService do
       xpath('./recurring:recurringDetailReference').must_be :empty?
     end
 
-    it "includes the shopper’s recurring detail reference if it is given" do
+    it "includes the shopper's recurring detail reference if it is given" do
       @recurring.params[:recurring_detail_reference] = 'RecurringDetailReference1'
       text('./recurring:recurringDetailReference').must_equal 'RecurringDetailReference1'
     end
@@ -162,11 +162,11 @@ describe Adyen::API::RecurringService do
       text('./recurring:merchantAccount').must_equal 'SuperShopper'
     end
 
-    it "includes the shopper’s reference" do
+    it "includes the shopper's reference" do
       text('./recurring:shopperReference').must_equal 'user-id'
     end
 
-    it "includes the shopper’s email" do
+    it "includes the shopper's email" do
       text('./recurring:shopperEmail').must_equal 's.hopper@example.com'
     end
 
@@ -181,7 +181,7 @@ describe Adyen::API::RecurringService do
       end
     end
 
-    it "formats the creditcard’s expiry month as a two digit number" do
+    it "formats the creditcard's expiry month as a two digit number" do
       @recurring.params[:card][:expiry_month] = 6
       text('./recurring:card/payment:expiryMonth').must_equal '06'
     end
@@ -199,11 +199,11 @@ describe Adyen::API::RecurringService do
       text('./recurring:merchantAccount').must_equal 'SuperShopper'
     end
 
-    it "includes the shopper’s reference" do
+    it "includes the shopper's reference" do
       text('./recurring:shopperReference').must_equal 'user-id'
     end
 
-    it "includes the shopper’s email" do
+    it "includes the shopper's email" do
       text('./recurring:shopperEmail').must_equal 's.hopper@example.com'
     end
 


### PR DESCRIPTION
Makes tests pass on JRuby 9.x