### PR TITLE
HPP SHA2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ comes without warranty of any kind, so use at your own risk.
 
 - `CHANGELOG.md` documents the changes between releases.
 - Check out `CONTRIBUTING.md` if you want to help out with this project.
+

--- a/lib/adyen/form.rb
+++ b/lib/adyen/form.rb
@@ -37,6 +37,16 @@ module Adyen
     # domain and payment flow to be filled.
     ACTION_URL = "https://%s/hpp/%s.shtml"
 
+    REQUIRED_PAYMENT_REQUEST_PARAMS = [
+        {key: :currency_code, name: 'currencyCode'},
+        {key: :merchant_account, name: 'merchantAccount'},
+        {key: :merchant_reference, name: 'merchantReference'},
+        {key: :payment_amount, name: 'paymentAmount'},
+        {key: :session_validity, name: 'sessionValidity'},
+        {key: :ship_before_date, name: 'shipBeforeDate'},
+        {key: :skin_code, name: 'skinCode'}
+    ].sort_by{ |obj| obj[:name] }
+
     # Returns the DOMAIN of the Adyen payment system, adjusted for an Adyen environment.
     #
     # @param [String] environment The Adyen environment to use. This parameter can be
@@ -234,16 +244,11 @@ module Adyen
     # @param [Hash] parameters The parameters that will be included in the payment request.
     # @return [String] The string for which the siganture is calculated.
     def calculate_signature_string(parameters)
-      merchant_sig_string = ""
-      merchant_sig_string << parameters[:payment_amount].to_s       << parameters[:currency_code].to_s         <<
-                             parameters[:ship_before_date].to_s     << parameters[:merchant_reference].to_s    <<
-                             parameters[:skin_code].to_s            << parameters[:merchant_account].to_s      <<
-                             parameters[:session_validity].to_s     << parameters[:shopper_email].to_s         <<
-                             parameters[:shopper_reference].to_s    << parameters[:recurring_contract].to_s    <<
-                             parameters[:allowed_methods].to_s      << parameters[:blocked_methods].to_s       <<
-                             parameters[:shopper_statement].to_s    << parameters[:merchant_return_data].to_s  <<
-                             parameters[:billing_address_type].to_s << parameters[:delivery_address_type].to_s <<
-                             parameters[:shopper_type].to_s         << parameters[:offset].to_s
+      merchant_sig_parts = REQUIRED_PAYMENT_REQUEST_PARAMS.map{ |obj| obj[:name] }
+      merchant_sig_parts += REQUIRED_PAYMENT_REQUEST_PARAMS.map{ |obj|
+        Adyen::Signature::escape_value(parameters[obj[:key]].to_s)
+      }
+      merchant_sig_parts.join(':')
     end
 
     # Calculates the payment request signature for the given payment parameters.

--- a/lib/adyen/signature.rb
+++ b/lib/adyen/signature.rb
@@ -30,7 +30,7 @@ module Adyen
     end
 
     def escape_value(value)
-      value.gsub(':', '\\:').gsub('\\', '\\\\')
+      value.gsub('\\', '\\\\\\\\').gsub(':', '\\:')
     end
 
     private

--- a/lib/adyen/signature.rb
+++ b/lib/adyen/signature.rb
@@ -29,6 +29,10 @@ module Adyen
       secure_compare(hmacSignature, our_sig)
     end
 
+    def escape_value(value)
+      value.gsub(':', '\\:').gsub('\\', '\\\\')
+    end
+
     private
 
     def string_to_sign(params, type)
@@ -55,10 +59,6 @@ module Adyen
       else
         hash.sort.map{ |el| el[1] }
       end
-    end
-
-    def escape_value(value)
-      value.gsub(':', '\\:').gsub('\\', '\\\\')
     end
 
     # Constant-time compare for two fixed-length strings

--- a/lib/adyen/util.rb
+++ b/lib/adyen/util.rb
@@ -6,6 +6,8 @@ module Adyen
   module Util
     extend self
 
+    DIGESTER = OpenSSL::Digest.new('sha256')
+
     # Returns a valid Adyen string representation for a date
     def format_date(date)
       case date
@@ -37,7 +39,8 @@ module Adyen
     # @param [String] message The message to sign.
     # @return [String] The signature, base64-encoded.
     def hmac_base64(hmac_key, message)
-      digest = OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha1'), hmac_key, message)
+      hexed_hmac_key = [hmac_key].pack("H*")
+      digest = OpenSSL::HMAC.digest(DIGESTER, hexed_hmac_key, message)
       Base64.strict_encode64(digest).strip
     end
 

--- a/test/unit/form_test.rb
+++ b/test/unit/form_test.rb
@@ -7,7 +7,7 @@ class FormTest < Minitest::Test
 
   def setup
     Adyen.configuration.default_form_params[:merchant_account] = 'TestMerchant'
-    Adyen.configuration.register_form_skin(:testing, '4aD37dJA', 'Kah942*$7sdp0)')
+    Adyen.configuration.register_form_skin(:testing, 'X7hsNDWp', '4468D9782DEF54FCD706C9100C71EC43932B1EBC2ACF6BA0560C05AAA7550C48')
     Adyen.configuration.register_form_skin(:other, 'sk1nC0de', 'shared_secret', merchant_account: 'OtherMerchant')
 
     # Use autodetection for the environment unless otherwise specified
@@ -15,13 +15,14 @@ class FormTest < Minitest::Test
     Adyen.configuration.payment_flow = :select
     Adyen.configuration.payment_flow_domain = nil
 
-    @payment_attributes = { 
-      :skin => :testing, 
-      :currency_code => 'GBP', 
-      :payment_amount => 10000,
-      :merchant_reference => 'Internet Order 12345',
-      :ship_before_date => '2007-10-20', 
-      :session_validity => '2007-10-11T11:00:00Z',
+    @payment_attributes = {
+      :skin => :testing,
+      :currency_code => 'EUR',
+      :payment_amount => 1995,
+      :merchant_reference => 'PAYMENTTEST:143522\\64\\39255',
+      :ship_before_date => '2015-07-01',
+      :session_validity => '2015-06-25T10:31:06Z',
+      :shopper_locale => 'en_GB',
       :billing_address => {
         :street               => 'Alexanderplatz',
         :house_number_or_name => '0815',
@@ -61,8 +62,8 @@ class FormTest < Minitest::Test
 
     @recurring_payment_attributes = @payment_attributes.merge(
       :skin               => :other,
-      :recurring_contract => 'DEFAULT', 
-      :shopper_reference  => 'grasshopper52', 
+      :recurring_contract => 'DEFAULT',
+      :shopper_reference  => 'grasshopper52',
       :shopper_email      => 'gras.shopper@somewhere.org'
     )
 
@@ -102,9 +103,9 @@ class FormTest < Minitest::Test
   end
 
   def test_redirect_url_generation
-    attributes = { 
+    attributes = {
       :currency_code => 'GBP', :payment_amount => 10000, :ship_before_date => Date.today,
-      :merchant_reference => 'Internet Order 12345', :skin => :testing, :session_validity => Time.now + 3600 
+      :merchant_reference => 'Internet Order 12345', :skin => :testing, :session_validity => Time.now + 3600
     }
 
     redirect_uri = URI(Adyen::Form.redirect_url(attributes))
@@ -119,9 +120,9 @@ class FormTest < Minitest::Test
   end
 
   def test_payment_methods_url_generation
-    attributes = { 
+    attributes = {
       :currency_code => 'GBP', :payment_amount => 10000, :ship_before_date => Date.today,
-      :merchant_reference => 'Internet Order 12345', :skin => :testing, :session_validity => Time.now + 3600 
+      :merchant_reference => 'Internet Order 12345', :skin => :testing, :session_validity => Time.now + 3600
     }
 
     redirect_uri = URI(Adyen::Form.payment_methods_url(attributes))
@@ -133,55 +134,76 @@ class FormTest < Minitest::Test
     end
 
     assert params.key?('merchantSig'), "Expected a merchantSig parameter to be set"
-  end  
+  end
 
   def test_redirect_signature_string
     signature_string = Adyen::Form.calculate_signature_string(@payment_attributes)
-    assert_equal "10000GBP2007-10-20Internet Order 123454aD37dJATestMerchant2007-10-11T11:00:00Z", signature_string
-
-    signature_string = Adyen::Form.calculate_signature_string(@payment_attributes.merge(:merchant_return_data => 'testing123'))
-    assert_equal "10000GBP2007-10-20Internet Order 123454aD37dJATestMerchant2007-10-11T11:00:00Ztesting123", signature_string
-
-    signature_string = Adyen::Form.calculate_signature_string(@recurring_payment_attributes)
-    assert_equal "10000GBP2007-10-20Internet Order 12345sk1nC0deOtherMerchant2007-10-11T11:00:00Zgras.shopper@somewhere.orggrasshopper52DEFAULT", signature_string
-
-    signature_string = Adyen::Form.calculate_signature_string(@payment_attributes.merge(:billing_address_type => '1', :delivery_address_type => '2'))
-    assert_equal "10000GBP2007-10-20Internet Order 123454aD37dJATestMerchant2007-10-11T11:00:00Z12", signature_string
-
-    signature_string = Adyen::Form.calculate_signature_string(@payment_attributes.merge(:delivery_address_type => '2', :shopper_type => '1'))
-    assert_equal "10000GBP2007-10-20Internet Order 123454aD37dJATestMerchant2007-10-11T11:00:00Z21", signature_string
+    assert_equal 'currencyCode:merchantAccount:merchantReference:paymentAmount:sessionValidity:shipBeforeDate:shopperLocale:skinCode:EUR:TestMerchant:PAYMENTTEST\:143522\\\\64\\\\39255:1995:2015-06-25T10\:31\:06Z:2015-07-01:en_GB:X7hsNDWp', signature_string
   end
 
-  def test_redirect_signature
-    assert_equal 'x58ZcRVL1H6y+XSeBGrySJ9ACVo=', Adyen::Form.calculate_signature(@payment_attributes)
-    assert_equal 'EZtZS/33I6qsXptTfRIFMJxeKFE=', Adyen::Form.calculate_signature(@recurring_payment_attributes)
+  def test_redirect_signature_string_with_missing_field
+    @payment_attributes.delete :shopper_locale
+    signature_string = Adyen::Form.calculate_signature_string(@payment_attributes)
+    assert_equal 'currencyCode:merchantAccount:merchantReference:paymentAmount:sessionValidity:shipBeforeDate:skinCode:EUR:TestMerchant:PAYMENTTEST\:143522\\\\64\\\\39255:1995:2015-06-25T10\:31\:06Z:2015-07-01:X7hsNDWp', signature_string
+  end
 
-    @payment_attributes.delete(:shared_secret)
-    assert_raises(ArgumentError) { Adyen::Form.calculate_signature(@payment_attributes) }
+  def test_redirect_signature_string_with_blank_field
+    @payment_attributes[:allowed_methods] = nil
+    signature_string = Adyen::Form.calculate_signature_string(@payment_attributes)
+    assert_equal 'allowedMethods:currencyCode:merchantAccount:merchantReference:paymentAmount:sessionValidity:shipBeforeDate:shopperLocale:skinCode::EUR:TestMerchant:PAYMENTTEST\:143522\\\\64\\\\39255:1995:2015-06-25T10\:31\:06Z:2015-07-01:en_GB:X7hsNDWp', signature_string
+  end
+
+  # signature_string = Adyen::Form.calculate_signature_string(@payment_attributes.merge(:merchant_return_data => 'testing123'))
+  # assert_equal "10000GBP2007-10-20Internet Order 12345X7hsNDWpTestMerchant2007-10-11T11:00:00Ztesting123", signature_string
+  #
+  # signature_string = Adyen::Form.calculate_signature_string(@recurring_payment_attributes)
+  # assert_equal "10000GBP2007-10-20Internet Order 12345sk1nC0deOtherMerchant2007-10-11T11:00:00Zgras.shopper@somewhere.orggrasshopper52DEFAULT", signature_string
+  #
+  # signature_string = Adyen::Form.calculate_signature_string(@payment_attributes.merge(:billing_address_type => '1', :delivery_address_type => '2'))
+  # assert_equal "10000GBP2007-10-20Internet Order 12345X7hsNDWpTestMerchant2007-10-11T11:00:00Z12", signature_string
+  #
+  # signature_string = Adyen::Form.calculate_signature_string(@payment_attributes.merge(:delivery_address_type => '2', :shopper_type => '1'))
+  # assert_equal "10000GBP2007-10-20Internet Order 12345X7hsNDWpTestMerchant2007-10-11T11:00:00Z21", signature_string
+
+  def test_redirect_signature
+    payment_attributes = {
+      :skin => :testing,
+      :currency_code => 'EUR',
+      :payment_amount => 199,
+      :merchant_reference => 'SKINTEST-1435226439255',
+      :ship_before_date => '2015-07-01',
+      :session_validity => '2015-06-25T10:31:06Z',
+      :shopper_locale => 'en_GB'
+    }
+    Adyen::Form.do_parameter_transformations!(payment_attributes)
+    assert_equal 'GJ1asjR5VmkvihDJxCd8yE2DGYOKwWwJCBiV3R51NFg=', Adyen::Form.calculate_signature(payment_attributes)
+
+    payment_attributes.delete(:shared_secret)
+    assert_raises(ArgumentError) { Adyen::Form.calculate_signature(payment_attributes) }
   end
 
   def test_shopper_signature
     signature_string = Adyen::Form.calculate_shopper_signature_string(@payment_attributes[:shopper])
     assert_equal "JohnDoe1234512345", signature_string
-    assert_equal 'rb2GEs1kGKuLh255a3QRPBYXmsQ=', Adyen::Form.calculate_shopper_signature(@payment_attributes)
+    assert_equal 'rog2ugjNPIRQnCdYXFr22SnJyxKKdSpPXxwKoRKH8t0=', Adyen::Form.calculate_shopper_signature(@payment_attributes)
 
     @payment_attributes.delete(:shared_secret)
-    assert_raises(ArgumentError) { Adyen::Form.calculate_shopper_signature(@payment_attributes) } 
+    assert_raises(ArgumentError) { Adyen::Form.calculate_shopper_signature(@payment_attributes) }
   end
 
   def test_billing_address_signature
     signature_string = Adyen::Form.calculate_billing_address_signature_string(@payment_attributes[:billing_address])
     assert_equal "Alexanderplatz0815Berlin10119BerlinGermany", signature_string
-    assert_equal '5KQb7VJq4cz75cqp11JDajntCY4=', Adyen::Form.calculate_billing_address_signature(@payment_attributes)
+    assert_equal 'hkE8BZJwmqCgqlYZgduAi2tkbZvHQixgzOp5TN0C1Ko=', Adyen::Form.calculate_billing_address_signature(@payment_attributes)
 
     @payment_attributes.delete(:shared_secret)
-    assert_raises(ArgumentError) { Adyen::Form.calculate_billing_address_signature(@payment_attributes) } 
+    assert_raises(ArgumentError) { Adyen::Form.calculate_billing_address_signature(@payment_attributes) }
   end
 
   def test_delivery_address_signature
     signature_string = Adyen::Form.calculate_delivery_address_signature_string(@payment_attributes[:delivery_address])
     assert_equal "Pecunialaan316Geldrop1234 ABNoneNetherlands", signature_string
-    assert_equal 'g8wPEWYrDPatkGXzuQbN1++JVbE=', Adyen::Form.calculate_delivery_address_signature(@payment_attributes)
+    assert_equal 'wfqwlkqW59BHL3CDgx9mUVCWIgUTm3IY26afhYmCMPQ=', Adyen::Form.calculate_delivery_address_signature(@payment_attributes)
 
     @payment_attributes.delete(:shared_secret)
     assert_raises(ArgumentError) { Adyen::Form.calculate_delivery_address_signature(@payment_attributes) }
@@ -218,7 +240,7 @@ class FormTest < Minitest::Test
       ].join(':')
 
     assert_equal expected_string, signature_string
-    assert_equal 'OI71VGB7G3vKBRrtE6Ibv+RWvYY=', Adyen::Form.calculate_open_invoice_signature(@payment_attributes)
+    assert_equal 'gBP6w4N0R4Svpd0wrho8LJAkNtouZo1GRetD2pFBd6o=', Adyen::Form.calculate_open_invoice_signature(@payment_attributes)
 
     @payment_attributes.delete(:shared_secret)
     assert_raises(ArgumentError) { Adyen::Form.calculate_open_invoice_signature(@payment_attributes) }
@@ -226,24 +248,24 @@ class FormTest < Minitest::Test
 
   def test_billing_signatures_in_redirect_url
     get_params = CGI.parse(URI(Adyen::Form.redirect_url(@payment_attributes)).query)
-    assert_equal '5KQb7VJq4cz75cqp11JDajntCY4=', get_params['billingAddressSig'].first
-    assert_equal 'g8wPEWYrDPatkGXzuQbN1++JVbE=', get_params['deliveryAddressSig'].first
-    assert_equal 'rb2GEs1kGKuLh255a3QRPBYXmsQ=', get_params['shopperSig'].first
-    assert_equal 'OI71VGB7G3vKBRrtE6Ibv+RWvYY=', get_params['openinvoicedata.sig'].first
-  end  
+    assert_equal 'hkE8BZJwmqCgqlYZgduAi2tkbZvHQixgzOp5TN0C1Ko=', get_params['billingAddressSig'].first
+    assert_equal 'wfqwlkqW59BHL3CDgx9mUVCWIgUTm3IY26afhYmCMPQ=', get_params['deliveryAddressSig'].first
+    assert_equal 'rog2ugjNPIRQnCdYXFr22SnJyxKKdSpPXxwKoRKH8t0=', get_params['shopperSig'].first
+    assert_equal 'gBP6w4N0R4Svpd0wrho8LJAkNtouZo1GRetD2pFBd6o=', get_params['openinvoicedata.sig'].first
+  end
 
   def test_redirect_signature_check
-    params = { 
+    params = {
       'authResult' => 'AUTHORISED', 'pspReference' => '1211992213193029',
-      'merchantReference' => 'Internet Order 12345', 'skinCode' => '4aD37dJA',
-      'merchantSig' => 'ytt3QxWoEhAskUzUne0P5VA9lPw='
+      'merchantReference' => 'Internet Order 12345', 'skinCode' => 'X7hsNDWp',
+      'merchantSig' => 'Dn7RdtNrxeM7JeQRFQOQF+Ui2sFN9SfeXs7oT2USOqE='
     }
 
     assert_equal params['merchantSig'], Adyen::Form.redirect_signature(params)
-    
+
     assert Adyen::Form.redirect_signature_check(params) # shared secret from registered skin
-    assert Adyen::Form.redirect_signature_check(params, 'Kah942*$7sdp0)') # explicitly provided shared secret
-    
+    assert Adyen::Form.redirect_signature_check(params, '4468D9782DEF54FCD706C9100C71EC43932B1EBC2ACF6BA0560C05AAA7550C48') # explicitly provided shared secret
+
     refute Adyen::Form.redirect_signature_check(params.merge('skinCode' => 'sk1nC0de'))
     refute Adyen::Form.redirect_signature_check(params, 'wrong_shared_secret')
 
@@ -260,9 +282,9 @@ class FormTest < Minitest::Test
 
 # http://example.com/result?merchantReference=HPP+test+order+%25231&skinCode=tifSfXeX&shopperLocale=en_GB&paymentMethod=visa&authResult=AUTHORISED&pspReference=8814131153369759&merchantSig=il8cjgOiG4N9l2PlSf6h4EVQ6hk%253D
     params = {
-      "merchantReference"=>CGI.unescape("HPP test order %231"), "skinCode"=>"tifSfXeX", 
-      "shopperLocale"=>"en_GB", "paymentMethod"=>"visa", "authResult"=>"AUTHORISED", 
-      "pspReference"=>"8814131148758652", "merchantSig"=> CGI.unescape("q8J9P%2Fp%2FYsbnnFn%2F83TFsv7Hais%3D")
+      "merchantReference"=>CGI.unescape("HPP test order %231"), "skinCode"=>"tifSfXeX",
+      "shopperLocale"=>"en_GB", "paymentMethod"=>"visa", "authResult"=>"AUTHORISED",
+      "pspReference"=>"8814131148758652", "merchantSig"=> CGI.unescape("IxXIrUnR7Au4QGx%2FxO3x6mhJoiQFRHd5mWIBgt%2BzsQA%3D")
     }
 
     assert_equal params['merchantSig'], Adyen::Form.redirect_signature(params)
@@ -276,11 +298,11 @@ class FormTest < Minitest::Test
     HTML
 
     for_each_xml_backend do
-      assert_adyen_single_payment_form payment_snippet, 
-        merchantAccount: 'TestMerchant', 
-        currencyCode: 'GBP', 
-        paymentAmount: '10000',
-        skinCode: '4aD37dJA'
+      assert_adyen_single_payment_form payment_snippet,
+        merchantAccount: 'TestMerchant',
+        currencyCode: 'EUR',
+        paymentAmount: '1995',
+        skinCode: 'X7hsNDWp'
     end
   end
 
@@ -292,10 +314,10 @@ class FormTest < Minitest::Test
     HTML
 
     for_each_xml_backend do
-      assert_adyen_recurring_payment_form recurring_snippet, 
-        merchantAccount: 'OtherMerchant', 
-        currencyCode: 'GBP', 
-        paymentAmount: '10000',
+      assert_adyen_recurring_payment_form recurring_snippet,
+        merchantAccount: 'OtherMerchant',
+        currencyCode: 'EUR',
+        paymentAmount: '1995',
         recurringContract: 'DEFAULT',
         skinCode: 'sk1nC0de'
     end

--- a/test/unit/util_test.rb
+++ b/test/unit/util_test.rb
@@ -5,7 +5,7 @@ require 'adyen/util'
 class UtilTest < Minitest::Test
   def test_hmac_base64_encoding
     encoded_str = Adyen::Util.hmac_base64('bla', 'bla')
-    assert_equal '6nItEkVpIYF+i1RwrEyQ7RHmrfU=', encoded_str
+    assert_equal 'KXKraGrg10DLZpodM0GLwHNGa2hdDygzktFMc+TwiqQ=', encoded_str
   end
 
   def test_gzip_base64_encoding


### PR DESCRIPTION
This PR fixes the hosted payment pages feature, which Adyen has migrated from using SHA1 to SHA2 now. What has changed is the way the `merchantSig` parameter is generated. It uses different parameters, concatenates them in a different way and then creates a hash, now using SHA2.
Tests are passing and I've also verified that it's working in production.

Missing:

* [ ] commented out a few tests I don't understand
* [ ] I have only added the params I needed to `PAYMENT_REQUEST_SIGNATURE_PARAMS` - there are probably a few missing
* [ ] travis-ci is failing because nokogiri has dropped support for Ruby 2.0