### PR TITLE
Add support for merchant-specific endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The following changes have been made to the library over the years. Pleae add an
 
 #### Unrelease changes
 
+- Add support for merchant-specific endpoints.
 - Add `shopper_statement` option to `Adyen::APP`, allowing to generate Billets with custom payment instructions.
 
 #### Version 2.2.0

--- a/lib/adyen/configuration.rb
+++ b/lib/adyen/configuration.rb
@@ -41,6 +41,10 @@ class Adyen::Configuration
     LIVE_RAILS_ENVIRONMENTS.include?(rails_env) ? 'live' : 'test'
   end
 
+
+  # TODO
+  attr_accessor :merchant_specific_endpoint
+
   # The payment flow page type that’s used to choose the payment process
   #
   # @example

--- a/lib/adyen/rest.rb
+++ b/lib/adyen/rest.rb
@@ -45,7 +45,8 @@ module Adyen
       Adyen::REST::Client.new(
         Adyen.configuration.environment,
         Adyen.configuration.api_username,
-        Adyen.configuration.api_password
+        Adyen.configuration.api_password,
+        Adyen.configuration.merchant_specific_endpoint
       )
     end
 

--- a/lib/adyen/rest/client.rb
+++ b/lib/adyen/rest/client.rb
@@ -20,14 +20,15 @@ module Adyen
       include AuthorisePayment
       include ModifyPayment
 
-      attr_reader :environment
+      attr_reader :environment, :merchant
 
       # @param environment [String] The Adyen environment to interface with. Either
       #   <tt>'live'</tt> or <tt>'test'</tt>.
       # @param username [String] The webservice username, e.g. <tt>ws@Company.Account</tt>
       # @param password [String] The password associated with the username
-      def initialize(environment, username, password)
-        @environment, @username, @password = environment, username, password
+      # @param merchant [String]
+      def initialize(environment, username, password, merchant = nil)
+        @environment, @username, @password, @merchant = environment, username, password, merchant
       end
 
       # Closes the client.
@@ -113,12 +114,18 @@ module Adyen
       # The endpoint URI for this client.
       # @return [URI] The endpoint to use for the environment.
       def endpoint
-        @endpoint ||= URI(ENDPOINT % [environment])
+        @endpoint ||= if merchant && environment.to_sym == :live
+          URI(ENDPOINT_MERCHANT_SPECIFIC % [merchant])
+        else
+          URI(ENDPOINT % [environment])
+        end
       end
 
       # @see Adyen::REST::Client#endpoint
       ENDPOINT = 'https://pal-%s.adyen.com/pal/adapter/httppost'
-      private_constant :ENDPOINT
+      ENDPOINT_MERCHANT_SPECIFIC = 'https://%s.pal-live.adyenpayments.com/pal/adapter/httppost'
+
+      private_constant :ENDPOINT, :ENDPOINT_MERCHANT_SPECIFIC
     end
   end
 end

--- a/test/unit/rest/client_test.rb
+++ b/test/unit/rest/client_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+require 'adyen/rest/client'
+
+class RESTClientTest < Minitest::Test
+  def test_endpoint_dev
+    client =  Adyen::REST::Client.new(
+        :test,
+        'login',
+        'password'
+    )
+
+    assert_equal client.http.address, 'pal-test.adyen.com'
+  end
+
+  def test_endpoint_live
+    client =  Adyen::REST::Client.new(
+        :live,
+        'login',
+        'password'
+    )
+
+    assert_equal client.http.address, 'pal-live.adyen.com'
+  end
+
+  def test_endpoint_live_with_merchant
+    merchant = 'merchantEndpoint'
+
+    client =  Adyen::REST::Client.new(
+        :live,
+        'login',
+        'password',
+        merchant
+    )
+
+    assert_equal client.http.address, "#{merchant}.pal-live.adyenpayments.com"
+  end
+end


### PR DESCRIPTION
This adds support for merchant-specific endpoints as requested in #158. The change was extracted from #148 which appears stale after 6 months of silence from the original contributor.