### PR TITLE
add "additional data" to SOAP List Recurring Details response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The following changes have been made to the library over the years. Pleae add an entry to this file as part of your pull requests.
 
+#### Unreleased changes
+- Add `additionalData` to response from `listRecurringDetails` recurring payment SOAP endpoint.
+
 #### Version 2.3.0
 
 - Add `shopper_statement` option to `Adyen::APP`, allowing to generate Billets with custom payment instructions.

--- a/test/unit/api/recurring_service_test.rb
+++ b/test/unit/api/recurring_service_test.rb
@@ -71,6 +71,7 @@ describe Adyen::API::RecurringService do
             :number => '1111'
           },
           :recurring_detail_reference => 'RecurringDetailReference1',
+          :additional_data => { "newAlias" => "123456" },
           :variant => 'mc',
           :creation_date => DateTime.parse('2009-10-27T11:50:12.178+01:00')
         },
@@ -85,6 +86,7 @@ describe Adyen::API::RecurringService do
             :holder_name => 'S. Hopper'
           },
           :recurring_detail_reference => 'RecurringDetailReference2',
+          :additional_data => { "newAlias" => "123456" },
           :variant => 'IDEAL',
           :creation_date => DateTime.parse('2009-10-27T11:26:22.216+01:00')
         },
@@ -97,6 +99,7 @@ describe Adyen::API::RecurringService do
             :bank_name        => 'TestBank',
           },
           :recurring_detail_reference => 'RecurringDetailReference3',
+          :additional_data => { "newAlias" => "123456" },
           :variant => 'elv',
           :creation_date => DateTime.parse('2009-10-27T11:26:22.216+01:00')
         }

--- a/test/unit/api/test_helper.rb
+++ b/test/unit/api/test_helper.rb
@@ -328,6 +328,12 @@ LIST_RESPONSE = <<EOS
             <elv xsi:nil="true"/>
             <name/>
             <recurringDetailReference>RecurringDetailReference1</recurringDetailReference>
+            <additionalData>
+              <entry>
+                <key xsi:type="xsd:string">newAlias</key>
+                <value xsi:type="xsd:string">123456</value>
+              </entry>
+            </additionalData>
             <variant>mc</variant>
           </RecurringDetail>
           <RecurringDetail>
@@ -345,6 +351,12 @@ LIST_RESPONSE = <<EOS
             <elv xsi:nil="true"/>
             <name/>
             <recurringDetailReference>RecurringDetailReference2</recurringDetailReference>
+            <additionalData>
+              <entry>
+                <key xsi:type="xsd:string">newAlias</key>
+                <value xsi:type="xsd:string">123456</value>
+              </entry>
+            </additionalData>
             <variant>IDEAL</variant>
           </RecurringDetail>
           <RecurringDetail>
@@ -360,6 +372,12 @@ LIST_RESPONSE = <<EOS
             <creationDate>2009-10-27T11:26:22.216+01:00</creationDate>
             <name/>
             <recurringDetailReference>RecurringDetailReference3</recurringDetailReference>
+            <additionalData>
+              <entry>
+                <key xsi:type="xsd:string">newAlias</key>
+                <value xsi:type="xsd:string">123456</value>
+              </entry>
+            </additionalData>
             <variant>elv</variant>
           </RecurringDetail>
         </details>


### PR DESCRIPTION
The [RecurringDetailsResult](https://docs.adyen.com/developers/api-reference/recurring-api#recurringdetailsresult) returned by the call to `listRecurringDetails` includes an array of [RecurringDetail](https://docs.adyen.com/developers/api-reference/recurring-api#recurringdetail) objects, each that may contain an [additionalData](https://docs.adyen.com/developers/api-reference/recurring-api#recurringdetailadditionaldata) object. With this change, the list response will return a hash of each key/value contained in the additional data.

Note: the parsing logic is the same as in [paymentService](https://github.com/wvanbergen/adyen/blob/master/lib/adyen/api/payment_service.rb#L343).