### PR TITLE
adds resURL parameter to hpp

### DIFF
--- a/lib/adyen/hpp/request.rb
+++ b/lib/adyen/hpp/request.rb
@@ -98,6 +98,7 @@ module Adyen
         formatted_parameters[:order_data]         = Adyen::Util.gzip_base64(formatted_parameters.delete(:order_data_raw)) if formatted_parameters[:order_data_raw]
         formatted_parameters[:ship_before_date]   = Adyen::Util.format_date(formatted_parameters[:ship_before_date])
         formatted_parameters[:session_validity]   = Adyen::Util.format_timestamp(formatted_parameters[:session_validity])
+        formatted_parameters[:res_URL]            = formatted_parameters.delete(:res_url) if formatted_parameters[:res_url]
         formatted_parameters
       end
 

--- a/test/unit/hpp_test.rb
+++ b/test/unit/hpp_test.rb
@@ -96,7 +96,8 @@ class HppTest < Minitest::Test
   def test_redirect_url_generation
     attributes = {
       :currency_code => 'GBP', :payment_amount => 10000, :ship_before_date => Date.parse('2015-10-26'),
-      :merchant_reference => 'Internet Order 12345', :session_validity => Time.parse('2015-10-26 10:30')
+      :merchant_reference => 'Internet Order 12345', :session_validity => Time.parse('2015-10-26 10:30'),
+      :res_url => 'http://example.com/shop'
     }
 
     request = Adyen::HPP::Request.new(attributes)
@@ -104,7 +105,8 @@ class HppTest < Minitest::Test
     processed_attributes = {
       'currencyCode' => 'GBP', 'paymentAmount' => '10000', 'shipBeforeDate' => '2015-10-26',
       'merchantReference' => 'Internet Order 12345', 'sessionValidity' => '2015-10-26T10:30:00Z',
-      'merchantAccount' => 'TestMerchant', 'skinCode' => @skin_code1, 'merchantSig' => 'ewDgqa+m3rMO6MOZfQ0ugWdwsu+otvRVBVujqGfgvb8='
+      'resURL' => 'http://example.com/shop',
+      'merchantAccount' => 'TestMerchant', 'skinCode' => @skin_code1, 'merchantSig' => 'BiRXWK/1sGwjCgQdFi1ShPyqFVGjKU3UqQfMhoyAGnQ='
     }
 
     redirect_uri = URI(request.redirect_url)


### PR DESCRIPTION
`resURL` lets your pass a custom return URL per HPP request.
Previously this param was formatted as `resUrl`, but Adyen wants `resURL`.