### PR TITLE
Replace poltergeist with capaybara-webkit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - "2.3.6"
   - "2.4.3"
   - "2.5.0"
-  - "jruby-9.0"
   - "jruby-9.1.15.0"
   - "ruby-head"
   - "rubinius-3"

--- a/adyen.gemspec
+++ b/adyen.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest', '~> 5.0')
   s.add_development_dependency('mocha')
   s.add_development_dependency('sinatra')
-  s.add_development_dependency('poltergeist')
+  s.add_development_dependency('capybara-webkit')
 
   s.add_development_dependency('railties', '>= 3.2', '< 6.0')
   s.add_development_dependency('nokogiri', '>= 1.6.8')

--- a/test/helpers/capybara.rb
+++ b/test/helpers/capybara.rb
@@ -1,12 +1,7 @@
 require 'helpers/example_server'
 require 'capybara/dsl'
-require 'capybara/poltergeist'
+require 'capybara/webkit'
 
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, phantomjs_options: ['--ssl-protocol=any'])
-end
-
-Capybara.default_driver = :poltergeist
-Capybara.javascript_driver = :poltergeist
+Capybara.default_driver = :webkit
+Capybara.javascript_driver = :webkit
 Capybara.app = Adyen::ExampleServer
-


### PR DESCRIPTION
There are maintenance problems with poltergeist's underlying driver, PhantomJS (see https://github.com/ariya/phantomjs/issues/15344 and related issues). Let's try capybara-webkit instead.