### PR TITLE
Update Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
-sudo: true
-dist: trusty
+sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - "2.0"
-  - "2.1"
   - "2.2"
-  - "2.3.6"
-  - "2.4.3"
-  - "2.5.0"
+  - "2.3"
+  - "2.4"
+  - "2.5"
   - "jruby-9.1.15.0"
   - "ruby-head"
   - "rubinius-3"


### PR DESCRIPTION
- Stop testing old Ruby versions.
- Change to `sudo: false` for CI workers with less overhead.