### PR TITLE
Remove parsing of psp_reference as Integer

### DIFF
--- a/lib/adyen/rest/response.rb
+++ b/lib/adyen/rest/response.rb
@@ -38,7 +38,7 @@ module Adyen
       end
 
       def psp_reference
-        Integer(self[:psp_reference])
+        self[:psp_reference]
       end
 
       protected

--- a/test/integration/hpp_integration_test.rb
+++ b/test/integration/hpp_integration_test.rb
@@ -39,7 +39,7 @@ class HPPIntegrationTest < Minitest::Test
     follow_redirect_back
 
     assert page.has_content?('Payment authorized')
-    assert_match /\A\d+\z/, find("#psp_reference").text
+    assert_match /\A\w+\z/, find("#psp_reference").text
     assert_equal order_uuid, find("#merchant_reference").text
   end
 

--- a/test/integration/payment_with_client_side_encryption_integration_test.rb
+++ b/test/integration/payment_with_client_side_encryption_integration_test.rb
@@ -21,6 +21,6 @@ class PaymentWithClientSideEncryptionIntegrationTest < Minitest::Test
     click_button('Pay')
 
     assert page.has_content?('Payment authorized')
-    assert_match /\A\d+\z/, find("#psp_reference").text
+    assert_match /\A\w+\z/, find("#psp_reference").text
   end
 end

--- a/test/unit/rest_response_test.rb
+++ b/test/unit/rest_response_test.rb
@@ -5,7 +5,7 @@ class RESTResponseTest < Minitest::Test
 
   def setup
     @http_response = mock
-    @http_response.stubs(body: 'result.a=123&result.b.c=456&result.camelCase=789')
+    @http_response.stubs(body: 'result.a=123&result.b.c=456&result.camelCase=789&result.pspReference=ABC123')
     @response = Adyen::REST::Response.new(@http_response, prefix: 'result')
   end
 
@@ -15,5 +15,7 @@ class RESTResponseTest < Minitest::Test
     assert_equal '123', @response['result.a']
     assert_equal '789', @response['camelCase']
     assert_equal '789', @response[:camel_case]
+    assert_equal 'ABC123', @response[:psp_reference]
+    assert_equal 'ABC123', @response.psp_reference
   end
 end


### PR DESCRIPTION
This PR removes the parsing of psp_reference as integer, as Adyen won't send Integer anymore: https://support.adyen.com/hc/en-us/articles/360002783080-How-to-check-if-my-integration-supports-alphanumeric-string-references-

This Fixes #189 