### PR TITLE
Remove PSP Reference Integer Parsing

### DIFF
--- a/lib/adyen/rest/response.rb
+++ b/lib/adyen/rest/response.rb
@@ -38,7 +38,7 @@ module Adyen
       end
 
       def psp_reference
-        Integer(self[:psp_reference])
+        self[:psp_reference]
       end
 
       protected

--- a/test/functional/api_test.rb
+++ b/test/functional/api_test.rb
@@ -111,7 +111,7 @@ if File.exist?(API_SPEC_INITIALIZER)
                                             { first_name: "Jow", last_name: "Silver" },
                                             "19762003691",
                                             "boletobancario_santander",
-                                            "2014-07-16T18:16:11Z",
+                                            "2020-07-16T18:16:11Z",
                                             "free-text billet payment instructions")
       response.must_be :success?
     end

--- a/test/integration/hpp_integration_test.rb
+++ b/test/integration/hpp_integration_test.rb
@@ -39,7 +39,7 @@ class HPPIntegrationTest < Minitest::Test
     follow_redirect_back
 
     assert page.has_content?('Payment authorized')
-    assert_match /\A\d+\z/, find("#psp_reference").text
+    assert_match /\A\w+\z/, find("#psp_reference").text
     assert_equal order_uuid, find("#merchant_reference").text
   end
 

--- a/test/integration/payment_with_client_side_encryption_integration_test.rb
+++ b/test/integration/payment_with_client_side_encryption_integration_test.rb
@@ -21,6 +21,6 @@ class PaymentWithClientSideEncryptionIntegrationTest < Minitest::Test
     click_button('Pay')
 
     assert page.has_content?('Payment authorized')
-    assert_match /\A\d+\z/, find("#psp_reference").text
+    assert_match /\A\w+\z/, find("#psp_reference").text
   end
 end


### PR DESCRIPTION
his PR removes the parsing of psp_reference as integer, as Adyen won't send Integer anymore: https://support.adyen.com/hc/en-us/articles/360002783080-How-to-check-if-my-integration-supports-alphanumeric-string-references-

This Fixes #189